### PR TITLE
Colours added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,12 @@ build:
 	npm run build
 
 audit:
-	  npm audit --audit-level=high
+	  npm run audit --audit-level=high
 
 test:
-	npm test
+	npm run test
 
-.PHONY: all debug build debug audit
+lint:
+	npm run lint
+
+.PHONY: all debug build debug audit lint

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -1,0 +1,15 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: node
+    tag: 14.15.4
+
+inputs:
+  - name: dp-design-system
+
+run:
+  path: dp-design-system/ci/scripts/lint.sh

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -6,5 +6,5 @@ pushd dp-design-system
   SHORT_REF=`git rev-parse --short HEAD`
 popd
 
-mkdir build/$SHORT_REF/
-cp -r dp-design-system/dist/css/main.css build/$SHORT_REF/main.css
+mkdir build/$SHORT_REF
+cp  dp-design-system/dist/css/main.css build/$SHORT_REF/main.css

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eux
+
+pushd dp-design-system
+  npm install --unsafe-perm
+  npm run lint
+popd

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "watch-css": "sass --style=compressed --watch scss:dist/css",
     "server": "http-server -p ${PORT:-9001} --cors",
     "dev": "npm run watch-css & npm run server",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "echo \"No linting specified\""
   },
   "repository": {
     "type": "git",

--- a/scss/abstracts/_colors.scss
+++ b/scss/abstracts/_colors.scss
@@ -35,26 +35,25 @@ $white: #FFF;
 $tints: (70, 40, 10);
 // colours to be used (currently all listed in colour palettes except greys)
 $tintable-colors: (
-        "spring-green": $spring-green,
-        "aqua-teal": $aqua-teal,
-        "sky-blue": $sky-blue,
-        "ocean-blue": $ocean-blue,
-        "night-blue": $night-blue,
-        "indigo-blue": $indigo-blue,
-        "plum-purple": $plum-purple,
-        "flamingo-pink": $flamingo-pink,
-        "ruby-red": $ruby-red,
-        "jaffa-orange": $jaffa-orange,
-        "sun-yellow": $sun-yellow,
-        "neon-yellow": $neon-yellow,
-        "leaf-green": $leaf-green
-);
-// Assignment
+        $spring-green,
+        $aqua-teal,
+        $sky-blue,
+        $ocean-blue,
+        $night-blue,
+        $indigo-blue,
+        $plum-purple,
+        $flamingo-pink,
+        $ruby-red,
+        $jaffa-orange,
+        $sun-yellow,
+        $neon-yellow,
+        $leaf-green);
 
+// Assignment
 $color-text: $black;
 $color-text-inverse: $white;
 
-$color-errors: $ruby-red;
+$color-error: $ruby-red;
 
 // ----------------------------------------------------- DP COLORS -----------------------------------------------------
 

--- a/scss/abstracts/_colors.scss
+++ b/scss/abstracts/_colors.scss
@@ -34,23 +34,21 @@ $white: #FFF;
 // Allowed tint percentages
 $tints: (70, 40, 10);
 // colours to be used (currently all listed in colour palettes except greys)
-// @formatter:off
 $tintable-colors: (
-        "spring-green":   $spring-green,
-        "aqua-teal":      $aqua-teal,
-        "sky-blue":       $sky-blue,
-        "ocean-blue":     $ocean-blue,
-        "night-blue":     $night-blue,
-        "indigo-blue":    $indigo-blue,
-        "plum-purple":    $plum-purple,
-        "flamingo-pink":  $flamingo-pink,
-        "ruby-red":       $ruby-red,
-        "jaffa-orange":   $jaffa-orange,
-        "sun-yellow":     $sun-yellow,
-        "neon-yellow":    $neon-yellow,
-        "leaf-green":     $leaf-green
+        "spring-green": $spring-green,
+        "aqua-teal": $aqua-teal,
+        "sky-blue": $sky-blue,
+        "ocean-blue": $ocean-blue,
+        "night-blue": $night-blue,
+        "indigo-blue": $indigo-blue,
+        "plum-purple": $plum-purple,
+        "flamingo-pink": $flamingo-pink,
+        "ruby-red": $ruby-red,
+        "jaffa-orange": $jaffa-orange,
+        "sun-yellow": $sun-yellow,
+        "neon-yellow": $neon-yellow,
+        "leaf-green": $leaf-green
 );
-// @formatter:on
 // Assignment
 
 $color-text: $black;
@@ -65,10 +63,10 @@ $color-errors: $ruby-red;
 $dp-chart-palette-1: ($ocean-blue, $sky-blue, $night-blue, #118C7B, $spring-green);
 
 // Palette 2
-$dp-chart-palette-2: append($dp-chart-palette-1, #871A6B, #F66068, #746CB1, #22D0B6);
+$dp-chart-palette-2: join($dp-chart-palette-1, (#871A6B, #F66068, #746CB1, #22D0B6));
 
 // Palette 3
-$dp-chart-palette-2: append($ocean-blue, $sky-blue, #871A6B, $spring-green, #F66068);
+$dp-chart-palette-3: ($ocean-blue, $sky-blue, #871A6B, $spring-green, #F66068);
 
 // Highlight color for all pallets
 $dp-chart-highlight: #F39431;

--- a/scss/abstracts/_functions.scss
+++ b/scss/abstracts/_functions.scss
@@ -1,16 +1,14 @@
-@import "colors";
-
 // ------------------------------------------------------ COLORS ------------------------------------------------------
 
 /// lighten a color
 @function tint($color, $percentage) {
-  @if index($tints, $percentage) {
-    @if map-has-key($tintable-colors, $color) {
+  @if index($tintable-colors, $color) {
+    @if index($tints, $percentage) {
       @return mix(white, $color, $percentage);
     }
-    @error "Unknown `#{$color}` in $tintable-colors. Please use an approved color";
+    @error "Invalid `#{$percentage}`. Please use an approved tint percentage such as: `#{$tints}`";
     @return null;
   }
-  @error "Unknown `#{$percentage}` in $tints. Please use an approved tint percentage";
+  @error "Invalid `#{$color}` Please use an approved tintable color such as: `#{$tintable-colors}`";
   @return null;
 }

--- a/scss/abstracts/_functions.scss
+++ b/scss/abstracts/_functions.scss
@@ -1,0 +1,16 @@
+@import "variables.scss";
+
+// ------------------------------------------------------ COLORS ------------------------------------------------------
+
+/// lighten a color
+@function tint($color, $percentage) {
+  @if index($tints, $percentage) {
+    @if map-has-key($tintable-colors, $color) {
+      @return mix(white, $color, $percentage);
+    }
+    @warn "Unknown `#{$color}` in $tintable-colors. Please use an approved color";
+    @return null;
+  }
+  @warn "Unknown `#{$percentage}` in $tints. Please use an approved tint percentage";
+  @return null;
+}

--- a/scss/abstracts/_functions.scss
+++ b/scss/abstracts/_functions.scss
@@ -1,4 +1,4 @@
-@import "variables.scss";
+@import "colors";
 
 // ------------------------------------------------------ COLORS ------------------------------------------------------
 
@@ -8,9 +8,9 @@
     @if map-has-key($tintable-colors, $color) {
       @return mix(white, $color, $percentage);
     }
-    @warn "Unknown `#{$color}` in $tintable-colors. Please use an approved color";
+    @error "Unknown `#{$color}` in $tintable-colors. Please use an approved color";
     @return null;
   }
-  @warn "Unknown `#{$percentage}` in $tints. Please use an approved tint percentage";
+  @error "Unknown `#{$percentage}` in $tints. Please use an approved tint percentage";
   @return null;
 }

--- a/scss/abstracts/_variables.scss
+++ b/scss/abstracts/_variables.scss
@@ -1,0 +1,74 @@
+// ------------------------------------------------------- COLORS ------------------------------------------------------
+// ----------------------------------------------------- ONS COLORS ----------------------------------------------------
+
+// --- ONS General palette ---
+$spring-green: #a8bd3a;
+$mint-green: #00a3a6;
+$sky-blue: #27a0cc;
+$ocean-blue: #206095;
+$night-blue: #003c57;
+
+// --- Census ---
+$indigo-blue: #3c388e;
+$plum-purple: #902082;
+$flamingo-pink: #df0667;
+
+// --- Supporting palette ---
+$ruby-red: #d0021b;
+$jaffa-orange: #f3781f;
+$sun-yellow: #fbc900;
+$neon-yellow: #f0f762;
+$leaf-green: #0f8243;
+
+// --- Grays ---
+$black: #222;
+$grey1: #414042;
+$grey2: #707071;
+$grey3: #bcbcbd;
+$grey4: #e2e2e3;
+$grey5: #f5f5f6;
+$white: #fff;
+
+
+// --- Tints ---
+// Allowed tint percentages
+$tints: (70, 40, 10);
+// colours to be used (currently all listed in colour palettes except greys)
+// @formatter:off
+$tintable-colors: (
+        "spring-green":  $spring-green,
+        "mint-green":    $mint-green,
+        "sky-blue":      $sky-blue,
+        "ocean-blue":    $ocean-blue,
+        "night-blue":    $night-blue,
+        "indigo-blue":   $indigo-blue,
+        "plum-purple":   $plum-purple,
+        "flamingo-pink": $flamingo-pink,
+        "ruby-red":      $ruby-red,
+        "jaffa-orange":  $jaffa-orange,
+        "sun-yellow":    $sun-yellow,
+        "neon-yellow":   $neon-yellow,
+        "leaf-green":    $leaf-green
+);
+// @formatter:on
+// Assignment
+
+$color-text: $black;
+$color-text-inverse: $white;
+
+$color-errors: $ruby-red;
+
+// ----------------------------------------------------- DP COLORS -----------------------------------------------------
+
+// --- Charts ---
+// Palette 1
+$dp-chart-palette-1: ($ocean-blue, $sky-blue, $night-blue, #118C7B, $spring-green);
+
+// Palette 2
+$dp-chart-palette-2: append($dp-chart-palette-1, #871A6B, #F66068, #746CB1, #22D0B6);
+
+// Palette 3
+$dp-chart-palette-2: append($ocean-blue, $sky-blue, #871A6B, $spring-green, #F66068);
+
+// Highlight color for all pallets
+$dp-chart-highlight: #F39431;

--- a/scss/abstracts/_variables.scss
+++ b/scss/abstracts/_variables.scss
@@ -2,32 +2,32 @@
 // ----------------------------------------------------- ONS COLORS ----------------------------------------------------
 
 // --- ONS General palette ---
-$spring-green: #a8bd3a;
-$mint-green: #00a3a6;
-$sky-blue: #27a0cc;
+$spring-green: #A8BD3A;
+$aqua-teal: #00A3A6;
+$sky-blue: #27A0CC;
 $ocean-blue: #206095;
-$night-blue: #003c57;
+$night-blue: #003C57;
 
 // --- Census ---
-$indigo-blue: #3c388e;
+$indigo-blue: #3C388E;
 $plum-purple: #902082;
-$flamingo-pink: #df0667;
+$flamingo-pink: #DF0667;
 
 // --- Supporting palette ---
-$ruby-red: #d0021b;
-$jaffa-orange: #f3781f;
-$sun-yellow: #fbc900;
-$neon-yellow: #f0f762;
-$leaf-green: #0f8243;
+$ruby-red: #D0021B;
+$jaffa-orange: #FE781F;
+$sun-yellow: #FBC900;
+$neon-yellow: #F0F762;
+$leaf-green: #0F8243;
 
 // --- Grays ---
 $black: #222;
 $grey1: #414042;
 $grey2: #707071;
-$grey3: #bcbcbd;
-$grey4: #e2e2e3;
-$grey5: #f5f5f6;
-$white: #fff;
+$grey3: #BCBCBD;
+$grey4: #E2E2E3;
+$grey5: #F5F5F6;
+$white: #FFF;
 
 
 // --- Tints ---
@@ -36,19 +36,19 @@ $tints: (70, 40, 10);
 // colours to be used (currently all listed in colour palettes except greys)
 // @formatter:off
 $tintable-colors: (
-        "spring-green":  $spring-green,
-        "mint-green":    $mint-green,
-        "sky-blue":      $sky-blue,
-        "ocean-blue":    $ocean-blue,
-        "night-blue":    $night-blue,
-        "indigo-blue":   $indigo-blue,
-        "plum-purple":   $plum-purple,
-        "flamingo-pink": $flamingo-pink,
-        "ruby-red":      $ruby-red,
-        "jaffa-orange":  $jaffa-orange,
-        "sun-yellow":    $sun-yellow,
-        "neon-yellow":   $neon-yellow,
-        "leaf-green":    $leaf-green
+        "spring-green":   $spring-green,
+        "aqua-teal":      $aqua-teal,
+        "sky-blue":       $sky-blue,
+        "ocean-blue":     $ocean-blue,
+        "night-blue":     $night-blue,
+        "indigo-blue":    $indigo-blue,
+        "plum-purple":    $plum-purple,
+        "flamingo-pink":  $flamingo-pink,
+        "ruby-red":       $ruby-red,
+        "jaffa-orange":   $jaffa-orange,
+        "sun-yellow":     $sun-yellow,
+        "neon-yellow":    $neon-yellow,
+        "leaf-green":     $leaf-green
 );
 // @formatter:on
 // Assignment

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -2,9 +2,9 @@
 
 // Configuration and helpers
 @import
+'abstracts/colors',
 'abstracts/functions',
-'abstracts/mixins',
-'abstracts/colors';
+'abstracts/mixins';
 
 // Base
 @import

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -2,9 +2,9 @@
 
 // Configuration and helpers
 @import
-'abstracts/variables',
 'abstracts/functions',
-'abstracts/mixins';
+'abstracts/mixins',
+'abstracts/colors';
 
 // Base
 @import


### PR DESCRIPTION
### What

- Colour variables added, ONS, DP and Chart colours
- Chart colours have no names. The only known use case is to loop through the pallet colours for charts
- Tint function added (uses mix, to mix in white to reproduce the correct 'tint' colours). This function only allows approved tint variants, if a new one is approved this can be added in the 'tints' variable, likewise only some colours are allowed tints, these can be edited via the tintable-colors variable. 
- 'Americanisms' have been used
- CI linting files added

_Note: I have opted to not create global utilities unless someone has a strong use case_ 


### How to review

1. Pull branch
2. Run Make debug
3. Create some classes and use the variables and tint function

Helpful note to access a specific chart colour you can use 'nth' e.g. `nth($dp-chart-palette-1,2)`
You can then use the custom-built tint function e.g. `tint(nth($dp-chart-palette-1,2), 40);` note this will fire an error as it isn't an allowed tintable colour (which is expected).

If you have a need for anything else added, changed or removed please to comment!

### Who can review

A future user of the dp-design-system e.g. UX, Dev team frontenders