### PR TITLE
Feature/input docs

### DIFF
--- a/src/scss/abstracts/mixins/_forms.scss
+++ b/src/scss/abstracts/mixins/_forms.scss
@@ -1,0 +1,22 @@
+// sizes passed to the input-width function; they should roughly correspond to the number of characters (e.g. input-width 4 = 4 characters).
+// Specific values were taken from the DST design system
+$input-widths: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50;
+
+// default character width value for mixin
+$char-max-width: 0.96rem;
+
+// input-width generates modifier classes that can be used to size an input
+@mixin input-width($class-name: "dp-input-width", $border-size: 1px, $horizontal-padding: 0.5rem, $char-size: $char-max-width) {
+    
+    // border offset: e.g. border: 1px solid red; = total offset of 2px
+    $border-offset: $border-size * 2;
+    
+    // padding offset: e.g. padding: 0 1rem; = total offset of 2rem
+    $horizontal-padding-offset: $horizontal-padding * 2;
+
+    @each $width in $input-widths {
+        .#{$class-name}--w-#{$width} {
+            max-width: calc(#{$char-size * $width} + #{$border-offset} + #{$horizontal-padding-offset})
+        }
+    }
+}

--- a/src/scss/components/_field.scss
+++ b/src/scss/components/_field.scss
@@ -1,0 +1,5 @@
+.dp-field {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    vertical-align: top;
+}

--- a/src/scss/components/_input.scss
+++ b/src/scss/components/_input.scss
@@ -1,12 +1,15 @@
+$dp-input-border-size: 1px;
+$dp-input-padding-size: 0.5rem;
+$numeric-character-size: 0.6rem;
+
 .dp-input {
   display: block;
   position: relative;
-  padding: 0.5rem;
+  padding: $dp-input-padding-size;
   width: 100%;
   z-index: 3;
 
-  border: 1px solid $black;
-
+  border: $dp-input-border-size solid $black;
   color: inherit;
   font-family: inherit;
   font-size: inherit;
@@ -38,3 +41,9 @@
     margin-bottom: 0.55rem;
   }
 }
+
+// generation utility for dp-input width modifiers (e.g. dp-input--w-4) for text/mixed cases, based on size of 'W' (largest character)
+@include input-width('dp-input', $dp-input-border-size, $dp-input-padding-size);
+
+// generation utility for dp-input width modifiers (e.g. dp-input-number--w-4) for numbers based on rough size of '4' number (largest charactre)
+@include input-width('dp-input-number', $dp-input-border-size, $dp-input-padding-size, $numeric-character-size);

--- a/src/scss/components/_input.scss
+++ b/src/scss/components/_input.scss
@@ -7,7 +7,6 @@ $numeric-character-size: 0.6rem;
   position: relative;
   padding: $dp-input-padding-size;
   width: 100%;
-  z-index: 3;
 
   border: $dp-input-border-size solid $black;
   color: inherit;

--- a/src/scss/components/_label.scss
+++ b/src/scss/components/_label.scss
@@ -5,6 +5,7 @@
     font-weight: $font-weight-bold;
     
     &__description {
+      display: inline-block;
       margin: 0.4rem 0;
       line-height: 1.4;
     }

--- a/src/scss/components/_label.scss
+++ b/src/scss/components/_label.scss
@@ -5,7 +5,6 @@
     font-weight: $font-weight-bold;
     
     &__description {
-      display: inline-block;
       margin: 0.4rem 0;
       line-height: 1.4;
     }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -8,7 +8,8 @@
 'abstracts/functions/helpers',
 'abstracts/functions/colors',
 'abstracts/functions/conversions',
-'abstracts/mixins/typography';
+'abstracts/mixins/typography',
+'abstracts/mixins/forms';
 
 // Base
 @import
@@ -20,4 +21,5 @@
 // Components
 @import
 'components/input',
-'components/label'
+'components/field',
+'components/label';

--- a/src/views/components/input/default/index.njk
+++ b/src/views/components/input/default/index.njk
@@ -5,6 +5,6 @@ layout: example
 ---
 
 <div class="dp-field">
-    <label class="dp-label dp-label--xl" for="default-example">Enter some text</label>
+    <label class="dp-label dp-label" for="default-example">Enter some text</label>
     <input type="text" id="default-example" class="dp-input">
 </div>

--- a/src/views/components/input/default/index.njk
+++ b/src/views/components/input/default/index.njk
@@ -1,0 +1,10 @@
+---
+title: Default Input
+description: LThe input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.
+layout: example
+---
+
+<div class="dp-field">
+    <label class="dp-label" for="default-example">Enter some text</label>
+    <input type="text" id="default-example" autocomplete="on" class="dp-input">
+</div>

--- a/src/views/components/input/default/index.njk
+++ b/src/views/components/input/default/index.njk
@@ -1,10 +1,10 @@
 ---
 title: Default Input
-description: LThe input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.
+description: The input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.
 layout: example
 ---
 
 <div class="dp-field">
-    <label class="dp-label" for="default-example">Enter some text</label>
+    <label class="dp-label dp-label--xl" for="default-example">Enter some text</label>
     <input type="text" id="default-example" autocomplete="on" class="dp-input">
 </div>

--- a/src/views/components/input/email/index.njk
+++ b/src/views/components/input/email/index.njk
@@ -1,10 +1,10 @@
 ---
-title: Default Input
+title: Input - email
 description: The input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.
 layout: example
 ---
 
 <div class="dp-field">
-    <label class="dp-label dp-label--xl" for="default-example">Enter some text</label>
-    <input type="text" id="default-example" class="dp-input">
+    <label class="dp-label dp-label" for="email">Email address</label>
+    <input type="email" id="email" autocomplete="email" class="dp-input">
 </div>

--- a/src/views/components/input/index.njk
+++ b/src/views/components/input/index.njk
@@ -15,7 +15,7 @@ eleventyNavigation:
 
 <section class="my-8">
     <h2 class="mb-4">When to use this component</h2>
-    <p>Use the input component when you need to let users enter alphanumeric information that is no longer than one line, such as their telephone number or email address.</p>
+    <p>Use the input component when you need to let users enter alphanumeric information that is no longer than one line, such as their name, telephone number or email address.</p>
 </section>
 
 <section class="mb-8">

--- a/src/views/components/input/index.njk
+++ b/src/views/components/input/index.njk
@@ -25,9 +25,9 @@ eleventyNavigation:
 
 <section class="mb-8">
     <h2 class="mb-4">How to use this component</h2>
-    <p>All input components must have a visible <a href="/components/label">label</a>.</p>
+    <p>All input components must have a visible <a href="/components/label">label</a>. Placeholder text is not an acceptable replacement for a label as it vanishes when a user starts typing.</p>
     <p>Inputs should be appropriately sized to help the user understand what they should enter by making them the right size for the content they are intended for.</p>
-    <p>By default, the input component will fill the width of its container. A width constraint class can be used to make the input smaller.</p>
+    <p>By default, the input component will fill the width of its container. A <a href="#width-constrained">width constraint</a> class can be used to make the input smaller.</p>
 
     <h3 class="mb-4">Description</h2>
     <p>An optional <code>dp-label__description</code> can be used to display a hint to help the user enter their information.</p>
@@ -37,7 +37,7 @@ eleventyNavigation:
 <section class="mb-8">
     <h2 class="mb-4">Variants</h2>
 
-    <h3 class="mb-4">Width constrained</h3>
+    <h3 class="mb-4" id="width-constrained">Width constrained</h3>
     <p>Where possible, you should make the inputs have the right width for the size of the content they are intended for in order to help users understand what they should enter.
     For example, UK postcodes never consist of more than 8 characters.</p>
 

--- a/src/views/components/input/index.njk
+++ b/src/views/components/input/index.njk
@@ -6,10 +6,10 @@ eleventyNavigation:
   key: Input
   section: components
 ---
+{% from "example.njk" import example %}
 
 <section>
     <p>The input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.</p>
-    {% from "example.njk" import example %}
     {{ example({group: "components", item: "input", example: "default", html: true, open: false }) }}
 </section>
 
@@ -28,4 +28,25 @@ eleventyNavigation:
     <p>All input components must have a visible <a href="/components/label">label</a>.</p>
     <p>Inputs should be appropriately sized to help the user understand what they should enter by making them the right size for the content they are intended for.</p>
     <p>By default, the input component will fill the width of its container. A width constraint class can be used to make the input smaller.</p>
+
+    <h3 class="mb-4">Description</h2>
+    <p>An optional <code>dp-label__description</code> can be used to display a hint to help the user enter their information.</p>
+    {{ example({group: "components", item: "input", example: "with-description", html: true, open: false }) }}
+</section>
+
+<section class="mb-8">
+    <h2 class="mb-4">Variants</h2>
+
+    <h3 class="mb-4">Width constrained</h3>
+    <p>Where possible, you should make the inputs have the right width for the size of the content they are intended for in order to help users understand what they should enter.
+    For example, UK postcodes never consist of more than 8 characters.</p>
+
+    <p>Inputs can have their widths constrained (but not limited) to the number of expected characters using the <code>dp-input--w-{value}</code> or <code>dp-input-number--w-{value}</code> classes.</p>
+
+    <p>Where an input will include <strong>any</strong> text, use <code>dp-input--w-{value}</code>.<p>
+    <p>Where an input will include <strong>only</strong> numeric values, use <code>dp-input-number--w-{value}</code>.<p>
+
+    <p>Available values to append for both classes are: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50.</p>
+    {{ example({group: "components", item: "input", example: "width-constraint", html: true, open: false, size: "l" }) }}
+
 </section>

--- a/src/views/components/input/index.njk
+++ b/src/views/components/input/index.njk
@@ -49,4 +49,7 @@ eleventyNavigation:
     <p>Available values to append for both classes are: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50.</p>
     {{ example({group: "components", item: "input", example: "width-constraint", html: true, open: false, size: "l" }) }}
 
+    <h3 class="mb-4">Email</h3>
+    <p>Setting the input <code>type</code> to <code>email</code> will bring up the correct keypad on touch devices.</p>
+    {{ example({group: "components", item: "input", example: "email", html: true, open: false }) }}
 </section>

--- a/src/views/components/input/index.njk
+++ b/src/views/components/input/index.njk
@@ -1,0 +1,31 @@
+---
+title: Input
+description: The input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.
+layout: default
+eleventyNavigation:
+  key: Input
+  section: components
+---
+
+<section>
+    <p>The input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.</p>
+    {% from "example.njk" import example %}
+    {{ example({group: "components", item: "input", example: "default", html: true, open: false }) }}
+</section>
+
+<section class="my-8">
+    <h2 class="mb-4">When to use this component</h2>
+    <p>Use the input component when you need to let users enter alphanumeric information that is no longer than one line, such as their telephone number or email address.</p>
+</section>
+
+<section class="mb-8">
+    <h2 class="mb-4">When not to use this component</h2>
+    <p>Do not use this component if you need to let users enter information that will span more than one line. In this case, you should use the <a href="/components/textarea">textarea</a> component.</p>
+</section>
+
+<section class="mb-8">
+    <h2 class="mb-4">How to use this component</h2>
+    <p>All input components must have a visible <a href="/components/label">label</a>.</p>
+    <p>Inputs should be appropriately sized to help the user understand what they should enter by making them the right size for the content they are intended for.</p>
+    <p>By default, the input component will fill the width of its container. A width constraint class can be used to make the input smaller.</p>
+</section>

--- a/src/views/components/input/width-constraint/index.njk
+++ b/src/views/components/input/width-constraint/index.njk
@@ -1,0 +1,35 @@
+---
+title: Input - width constraint variations
+description: The input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.
+layout: example
+---
+
+<div class="dp-field">
+    <label class="dp-label" for="30-char-example">30 character width</label>
+    <input type="text" id="30-char-example" autocomplete="on" class="dp-input dp-input--w-30">
+</div>
+
+<div class="dp-field">
+    <label class="dp-label" for="30-numeric-example">30 numeric width</label>
+    <input type="text" id="30-numeric-example" autocomplete="on" class="dp-input dp-input-number--w-30">
+</div>
+
+<div class="dp-field">
+    <label class="dp-label" for="15-char-example">15 character width</label>
+    <input type="text" id="15-char-example" autocomplete="on" class="dp-input dp-input--w-15">
+</div>
+
+<div class="dp-field">
+    <label class="dp-label" for="15-numeric-example">15 numeric width</label>
+    <input type="text" id="15-numeric-example" autocomplete="on" class="dp-input dp-input-number--w-15">
+</div>
+
+<div class="dp-field">
+    <label class="dp-label" for="5-char-example">5 character width</label>
+    <input type="text" id="5-char-example" autocomplete="on" class="dp-input dp-input--w-5">
+</div>
+
+<div class="dp-field">
+    <label class="dp-label" for="5-numeric-example">5 numeric width</label>
+    <input type="text" id="5-numeric-example" autocomplete="on" class="dp-input dp-input-number--w-5">
+</div>

--- a/src/views/components/input/width-constraint/index.njk
+++ b/src/views/components/input/width-constraint/index.njk
@@ -6,30 +6,30 @@ layout: example
 
 <div class="dp-field">
     <label class="dp-label" for="30-char-example">30 character width</label>
-    <input type="text" id="30-char-example" autocomplete="on" class="dp-input dp-input--w-30">
+    <input type="text" id="30-char-example" class="dp-input dp-input--w-30">
 </div>
 
 <div class="dp-field">
     <label class="dp-label" for="30-numeric-example">30 numeric width</label>
-    <input type="text" id="30-numeric-example" autocomplete="on" class="dp-input dp-input-number--w-30">
+    <input type="text" id="30-numeric-example" class="dp-input dp-input-number--w-30">
 </div>
 
 <div class="dp-field">
     <label class="dp-label" for="15-char-example">15 character width</label>
-    <input type="text" id="15-char-example" autocomplete="on" class="dp-input dp-input--w-15">
+    <input type="text" id="15-char-example" class="dp-input dp-input--w-15">
 </div>
 
 <div class="dp-field">
     <label class="dp-label" for="15-numeric-example">15 numeric width</label>
-    <input type="text" id="15-numeric-example" autocomplete="on" class="dp-input dp-input-number--w-15">
+    <input type="text" id="15-numeric-example" class="dp-input dp-input-number--w-15">
 </div>
 
 <div class="dp-field">
     <label class="dp-label" for="5-char-example">5 character width</label>
-    <input type="text" id="5-char-example" autocomplete="on" class="dp-input dp-input--w-5">
+    <input type="text" id="5-char-example" class="dp-input dp-input--w-5">
 </div>
 
 <div class="dp-field">
     <label class="dp-label" for="5-numeric-example">5 numeric width</label>
-    <input type="text" id="5-numeric-example" autocomplete="on" class="dp-input dp-input-number--w-5">
+    <input type="text" id="5-numeric-example" class="dp-input dp-input-number--w-5">
 </div>

--- a/src/views/components/input/with-description/index.njk
+++ b/src/views/components/input/with-description/index.njk
@@ -7,5 +7,5 @@ layout: example
 <div class="dp-field">
     <label class="dp-label dp-label--xl dp-label--with-description" for="description-example">What are the details?</label>
     <div class="dp-label__description">For example, if you were searching for something, what did you type into the search box?</div>
-    <input type="text" id="description-example" autocomplete="on" class="dp-input">
+    <input type="text" id="description-example" class="dp-input">
 </div>

--- a/src/views/components/input/with-description/index.njk
+++ b/src/views/components/input/with-description/index.njk
@@ -1,0 +1,11 @@
+---
+title: Input - with description
+description: The input component lets users enter alphanumeric characters for answers that are no longer than one line, using the appropriate keyboard on touch devices.
+layout: example
+---
+
+<div class="dp-field">
+    <label class="dp-label dp-label--xl dp-label--with-description" for="description-example">What are the details?</label>
+    <div class="dp-label__description">For example, if you were searching for something, what did you type into the search box?</div>
+    <input type="text" id="description-example" autocomplete="on" class="dp-input">
+</div>

--- a/src/views/components/input/with-description/index.njk
+++ b/src/views/components/input/with-description/index.njk
@@ -5,7 +5,7 @@ layout: example
 ---
 
 <div class="dp-field">
-    <label class="dp-label dp-label--xl dp-label--with-description" for="description-example">What are the details?</label>
+    <label class="dp-label dp-label--with-description" for="description-example">What are the details?</label>
     <span class="dp-label__description">For example, if you were searching for something, what did you type into the search box?</span>
     <input type="text" id="description-example" class="dp-input">
 </div>

--- a/src/views/components/input/with-description/index.njk
+++ b/src/views/components/input/with-description/index.njk
@@ -6,6 +6,6 @@ layout: example
 
 <div class="dp-field">
     <label class="dp-label dp-label--xl dp-label--with-description" for="description-example">What are the details?</label>
-    <div class="dp-label__description">For example, if you were searching for something, what did you type into the search box?</div>
+    <span class="dp-label__description">For example, if you were searching for something, what did you type into the search box?</span>
     <input type="text" id="description-example" class="dp-input">
 </div>

--- a/src/views/components/label/index.njk
+++ b/src/views/components/label/index.njk
@@ -7,8 +7,12 @@ eleventyNavigation:
   section: components
 ---
 
-{% from "example.njk" import example %}
-{{ example({group: "components", item: "label", example: "default", html: true, open: false, size: "s" }) }}
+<section>
+    <p>Labels are paired with inputs, textareas, radios, checkboxes, and selects to describe a form input.</p>
+    {% from "example.njk" import example %}
+    {{ example({group: "components", item: "label", example: "default", html: true, open: false, size: "s" }) }}
+</section>
+
 
 <section class="my-8">
     <h2 class="mb-4">When to use this component</h2>
@@ -24,7 +28,7 @@ eleventyNavigation:
 <section class="mb-8">
     <h2 class="mb-4">How to use this component</h2>
     <p>Generally speaking you <strong>should not</strong> need to implement a label yourself as the form inputs have them imported in their respective templates.</p>
-    <p>All input and textarea components must have a visible label.</p>
+    <p>All <a href="/components/input">input</a> and <a href="/components/textarea">textarea</a> components must have a visible label.</p>
 
     <h3>Do:</h3>
     <ul class="mb-6 list-disc list-inside">

--- a/src/views/components/textarea/default/index.njk
+++ b/src/views/components/textarea/default/index.njk
@@ -5,7 +5,7 @@ layout: example
 ---
 
 <div class="dp-field">
-    <label class="dp-label dp-label--l dp-label--with-description" for="default">Please provide feedback</label>
+    <label class="dp-label dp-label--with-description" for="default">Please provide feedback</label>
     <span class="dp-label__description">For example describe any difficulties you experienced in the use of this service</span>
     <textarea rows=8 class="dp-input dp-input--textarea" id="default"></textarea>
 </div>

--- a/src/views/components/textarea/index.njk
+++ b/src/views/components/textarea/index.njk
@@ -7,8 +7,11 @@ eleventyNavigation:
   section: components
 ---
 
-{% from "example.njk" import example %}
-{{ example({group: "components", item: "textarea", example: "default", html: true, open: false, size: "m" }) }}
+<section>
+    <p>A textarea lets users enter multiple lines of text, such as when answering an open-ended question.</p>
+    {% from "example.njk" import example %}
+    {{ example({group: "components", item: "textarea", example: "default", html: true, open: false, size: "m" }) }}
+</section>
 
 <section class="my-8">
     <h2 class="mb-4">When to use this component</h2>

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -12,7 +12,9 @@
         <link rel="stylesheet" href="/assets/css/main.css">
         <link rel="stylesheet" href="/assets/css/tailwind.css">
         <link rel="stylesheet" href="/assets/css/main.css">
-        <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
+        {% if collectionName == "Components" %}
+            <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
+        {% endif %}
         <meta name="robots" content="noindex, nofollow">
     </head>
     <body>

--- a/src/views/partials/example.njk
+++ b/src/views/partials/example.njk
@@ -34,7 +34,7 @@
                 example in a new tab
             </a>
         </div>
-        <iframe title="{{ params.item + " example" }}" id="{{ componentLabel }}-iframe" class="block border-0 w-full {{panelHeight}}" src="{{ exampleURL }}" frameBorder="0" loading="lazy">
+        <iframe title="{{ params.item + " example" }}" id="{{ componentLabel }}-iframe" class="block border-0 w-full resize-y {{panelHeight}}" src="{{ exampleURL }}" frameBorder="0" loading="lazy">
         </iframe>
         <ul class="my-0 mx-auto overflow-visible list-none border-t border-grey-2" role="tablist">
             <li class="text-ocean-blue inline-block p-4 cursor-pointer font-bold" role="tab" aria-controls="{{ componentLabel }}-html" data-track="tab-html" tabindex="0">HTML</li>

--- a/src/views/partials/example.njk
+++ b/src/views/partials/example.njk
@@ -21,7 +21,7 @@
 {% elif params.size == "m" %}
     {% set panelHeight = "h-80" %}
 {% else %}
-    {% set panelHeight = "h-32" %}
+    {% set panelHeight = "h-44" %}
 {% endif %}
 
 <div class="my-4">

--- a/src/views/partials/example.njk
+++ b/src/views/partials/example.njk
@@ -21,10 +21,10 @@
 {% elif params.size == "m" %}
     {% set panelHeight = "h-80" %}
 {% else %}
-    {% set panelHeight = "h-52" %}
+    {% set panelHeight = "h-32" %}
 {% endif %}
 
-<div class="my-8">
+<div class="my-4">
     {% if display %}
     <div class="relative border border-grey-2 {{ "mb-0" if params.html }}">
         <div class="border-b border-grey-2 py-2 px-4">


### PR DESCRIPTION
### What

Basic input component documentation and implementation

- Mixin for calculating width based on character width. I'd intended to use `ch` but the implementation of it is different with Chrome/Firefox/Safari vs. IE11, which would've added more complexity, so I opted to use `rem`
- Docs for input component with basic examples - default, with description, character/numeric width
- I've not yet included any error state examples as I was thinking this might be better served as a separate piece of work
- Added the summary to the top of the textarea component docs to make it consistent with the input one

### How to review

- Check that changes make sense
- Check docs for SPAG, that it's clear etc
- Review styling tweaks/mixin

### Who can review

Anyone
