### PR TITLE
increase size of page title to xxxl

### DIFF
--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -27,7 +27,7 @@
                 <div class="col-span-9 p-6">
                     <main id="main">
                         <div class="text-grey-2 text-lg mb-1">{{collectionName}}</div>
-                        <h1 class="mb-8">{{title}}</h1>
+                        <h1 class="mb-8 dp-fs-xxxl">{{title}}</h1>
                         {{ content | safe }}
                     </main>
                 </div>


### PR DESCRIPTION
### What

Bumped the font size of the page title (h1) of the default template up to `xxxl`. 

### How to review

Before

<img width="1252" alt="Screenshot 2021-04-19 at 14 51 53" src="https://user-images.githubusercontent.com/930398/115247605-d768ea00-a11e-11eb-9dbf-fd5e1e8054d9.png">

After

<img width="1252" alt="Screenshot 2021-04-19 at 14 51 33" src="https://user-images.githubusercontent.com/930398/115247616-da63da80-a11e-11eb-89de-4ed848817808.png">

### Who can review

Anyone
