### PR TITLE
Docs/button

### DIFF
--- a/src/scss/abstracts/functions/_helpers.scss
+++ b/src/scss/abstracts/functions/_helpers.scss
@@ -45,3 +45,10 @@
     @error 'Breakpoint #{$name} wasn\'t found in $breakpoints: #{$breakpoints}';
   }
 }
+
+// convert a pixel value to em unit
+@function ems($pxval, $base: $base) {
+  $em-size: $pxval / $base;
+
+  @return #{$em-size}em;
+}

--- a/src/scss/abstracts/variables/_colors.scss
+++ b/src/scss/abstracts/variables/_colors.scss
@@ -56,6 +56,9 @@ $color-focus: $jaffa-orange;
 
 $error-color: $ruby-red;
 $link-color: $ocean-blue;
+
+$button-color: $leaf-green;
+$button-secondary-color: $grey4;
 // ----------------------------------------------------- DP COLORS -----------------------------------------------------
 
 // --- Charts ---

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -65,8 +65,7 @@ $button-border-height: 3px;
     }
   }
 
-  &--secondary &,
-  &--print & {
+  &--secondary & {
     &__inner {
       background: $button-secondary-color;
       color: $text-color;
@@ -78,8 +77,7 @@ $button-border-height: 3px;
   }
 
   // When hovered
-  &--secondary:hover &,
-  &--print:hover & {
+  &--secondary:hover & {
     &__inner {
       background: darken($button-secondary-color, 5%);
     }
@@ -100,7 +98,7 @@ $button-border-height: 3px;
     color: $text-color;
   }
 
-  &:not([class*='dp-button--secondary']):not([class*='dp-button--print']):focus:hover
+  &:not([class*='dp-button--secondary']):focus:hover
     &__inner {
     color: $text-color-inverse;
   }

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -1,0 +1,117 @@
+$button-border-height: 3px;
+
+.dp-button {
+  font-family: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: $font-weight-bold;
+  line-height: 1.35;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-rendering: optimizeLegibility;
+  vertical-align: top;
+
+  &::after {
+    border: ems($button-border-height) solid transparent;
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  .svg-icon {
+    fill: $text-color-inverse;
+    height: 0.8rem;
+    margin: 0 0 0.1rem 0.5rem;
+    vertical-align: middle;
+    width: 0.8rem;
+  }
+
+  &:hover & {
+    &__inner {
+      background: darken($button-color, 5%);
+    }
+  }
+
+  &__inner {
+    background: $button-color;
+    border-bottom: ems($button-border-height) solid rgba(0, 0, 0, 0.6);
+    color: $text-color-inverse;
+    display: inherit;
+    padding: 0.75em 1em;
+    // Required for Google Tag Manager
+    pointer-events: none;
+  }
+
+  // Modifiers
+  &--small,
+  &--mobile {
+    @include font-size(map-get($type-matrix, 'dp-fs-s--b'), $base);
+  }
+
+  &--small &,
+  &--mobile & {
+    &__inner {
+      padding: 0.5em 0.7em;
+    }
+  }
+
+  &--secondary &,
+  &--print & {
+    &__inner {
+      background: $button-secondary-color;
+      color: $text-color;
+      font-weight: normal;
+      .svg-icon {
+        fill: $text-color;
+      }
+    }
+  }
+
+  // When hovered
+  &--secondary:hover &,
+  &--print:hover & {
+    &__inner {
+      background: darken($button-secondary-color, 5%);
+    }
+  }
+
+  // When preceded by another button (e.g. in a group)
+  & + & {
+    margin-left: 0.5rem;
+  }
+
+  // When focussed
+  &:focus:not(:active):not(:hover) {
+    outline: 3px solid transparent;
+  }
+
+  &:focus:not(:active):not(:hover) &__inner {
+    background-color: $color-focus;
+    color: $text-color;
+  }
+
+  &:not([class*='dp-button--secondary']):not([class*='dp-button--print']):focus:hover
+    &__inner {
+    color: $text-color-inverse;
+  }
+
+  &:disabled {
+    &:hover {
+      cursor: not-allowed;
+    }
+
+    > .dp-button__inner {
+      opacity: 0.4;
+    }
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -20,6 +20,7 @@
 
 // Components
 @import
+'components/button',
 'components/input',
 'components/field',
 'components/label';

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -22,6 +22,10 @@ h2 {
   @apply text-2xl mb-4 font-bold;
 }
 
+h3 {
+  @apply text-xl mb-3 font-bold;
+}
+
 p {
   @apply mb-4;
   max-width: 50em;

--- a/src/views/components/button/default/index.njk
+++ b/src/views/components/button/default/index.njk
@@ -1,0 +1,9 @@
+---
+title: Default Primary Button
+description: The button component is used to direct the user to perform a specific interaction.
+layout: example
+---
+
+<button type="submit" class="dp-button">
+    <span class="dp-button__inner">Save and continue</span>
+</button>

--- a/src/views/components/button/disabled/index.njk
+++ b/src/views/components/button/disabled/index.njk
@@ -1,0 +1,9 @@
+---
+title: Disabled Button
+description: The button component is used to direct the user to perform a specific interaction.
+layout: example
+---
+
+<button type="submit" class="dp-button" disabled="true">
+    <span class="dp-button__inner">Submit</span>
+</button>

--- a/src/views/components/button/group/index.njk
+++ b/src/views/components/button/group/index.njk
@@ -1,0 +1,15 @@
+---
+title: Grouped Buttons
+description: The button component is used to direct the user to perform a specific interaction.
+layout: example
+---
+
+<div class="dp-button-group">
+    <button type="submit" class="dp-button">
+        <span class="dp-button__inner">Continue</span>
+    </button>
+
+    <button type="submit" class="dp-button dp-button--secondary">
+        <span class="dp-button__inner">Cancel</span>
+    </button>
+</div>

--- a/src/views/components/button/index.njk
+++ b/src/views/components/button/index.njk
@@ -1,0 +1,53 @@
+---
+title: Button
+description: The button component is used to direct the user to perform a specific interaction.
+layout: default
+eleventyNavigation:
+  key: Button
+  section: components
+---
+{% from "example.njk" import example %}
+
+<section>
+    {{ example({group: "components", item: "button", example: "default", size: "s", html: true, open: false }) }}
+</section>
+
+<section class="my-8">
+    <h2 class="mb-4">When to use this component</h2>
+        <p>Buttons are used to direct the user to perform a specific interaction. 
+    The copy used on the button should be clear, concise and direct.</p>
+</section>
+
+<section class="my-8">
+    <h2 class="mb-4">How it works</h2>
+        <p>Write button text in sentence case, describing the action it performs. For example ‘Save and continue’ or ‘Start now’.</p>
+        <p>Align the primary action button to the left edge of your form.</p>
+</section>
+
+<section class="mb-8">
+    <h2 class="mb-4">Variants</h2>
+
+    <h3 class="mb-4" id="small">Small</h3>
+    <p>In certain circumstances there may be the need for multiple primary actions to exist on a page. 
+    The small primary button should be used in this scenario only when each action has the same context.</p>
+    {{ example({group: "components", item: "button", example: "small", html: true, open: false, size: "s" }) }}
+
+    <h3 class="mb-4" id="secondary">Secondary</h3>
+    <p>Secondary buttons should be used for supplementary actions which users can take. 
+    Secondary buttons <strong>cannot</strong> exist without a primary button in the same context.</p>
+    {{ example({group: "components", item: "button", example: "secondary", size: "s", html: true, open: false }) }}
+
+    <h3 class="mb-4" id="secondary-small">Secondary Small</h3>
+    <p>A small secondary button should be used within the same context of a primary small button when there is an 
+    additional action available along with the primary action.</p>
+    {{ example({group: "components", item: "button", example: "secondary-small", html: true, open: false, size: "s" }) }}
+
+    <h3 class="mb-4" id="group">Group</h3>
+    <p>Groups are used to group two or more buttons together and easily align them alongside eachother. 
+    This will allow for a page to have two actions available to the user such as Continue and Cancel.</p>
+    {{ example({group: "components", item: "button", example: "group", html: true, open: false, size: "s" }) }}
+
+    <h3 class="mb-4" id="disabled">Disabled</h3>
+    <p>Button disabled styling will be applied when the element attribute, <code>disabled=true</code>, is set.</p>
+    {{ example({group: "components", item: "button", example: "disabled", html: true, open: false, size: "s" }) }}
+</section>

--- a/src/views/components/button/secondary-small/index.njk
+++ b/src/views/components/button/secondary-small/index.njk
@@ -1,0 +1,9 @@
+---
+title: Small Secondary Button
+description: The button component is used to direct the user to perform a specific interaction.
+layout: example
+---
+
+<button type="submit" class="dp-button dp-button--secondary dp-button--small">
+    <span class="dp-button__inner">Add</span>
+</button>

--- a/src/views/components/button/secondary-small/index.njk
+++ b/src/views/components/button/secondary-small/index.njk
@@ -5,5 +5,5 @@ layout: example
 ---
 
 <button type="submit" class="dp-button dp-button--secondary dp-button--small">
-    <span class="dp-button__inner">Add</span>
+    <span class="dp-button__inner">Add another person</span>
 </button>

--- a/src/views/components/button/secondary/index.njk
+++ b/src/views/components/button/secondary/index.njk
@@ -1,0 +1,9 @@
+---
+title: Secondary Button
+description: The button component is used to direct the user to perform a specific interaction.
+layout: example
+---
+
+<button type="button" class="dp-button dp-button--secondary">
+    <span class="dp-button__inner">Add a person</span>
+</button>

--- a/src/views/components/button/small/index.njk
+++ b/src/views/components/button/small/index.njk
@@ -1,0 +1,9 @@
+---
+title: Small Primary Button
+description: The button component is used to direct the user to perform a specific interaction.
+layout: example
+---
+
+<button type="submit" class="dp-button dp-button--small">
+    <span class="dp-button__inner">csv (78 KB)</span>
+</button>

--- a/src/views/layouts/example.njk
+++ b/src/views/layouts/example.njk
@@ -8,9 +8,10 @@
         <link rel="shortcut icon" href="/assets/images/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="/assets/css/main.css">
         <meta name="robots" content="noindex, nofollow">
+        <style>main { padding: 1rem; }</style>
     </head>
     <body>
-        <main style="padding: 1rem;" id="main">
+        <main id="main">
             {{ content | safe }}
         </main>
     </body>

--- a/src/views/layouts/example.njk
+++ b/src/views/layouts/example.njk
@@ -6,12 +6,11 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ title }} | Example | Design System | ONS — Digital Publishing </title>
         <link rel="shortcut icon" href="/assets/images/favicon.ico" type="image/x-icon">
-        <link rel="stylesheet" href="/assets/css/tailwind.css">
         <link rel="stylesheet" href="/assets/css/main.css">
         <meta name="robots" content="noindex, nofollow">
     </head>
     <body>
-        <main class="p-4" id="main">
+        <main style="padding: 1rem;" id="main">
             {{ content | safe }}
         </main>
     </body>


### PR DESCRIPTION
### What

- Implemented button component as per DST design system (without rounded corners)
- Added basic variants - primary/secondary, small size, button grouping, and disabled
- There are some variants that I have not ported over from the DST design system as I do not think they will be in use for now; if work forthcoming does include them, then we can perhaps add when necessary
- Removed Tailwind from the examples layout. It's a relatively large request that is loaded for every example component that's on the page (given that we iframe them in). The only style we use from tailwind is to apply padding; as such I've simply added it to some style tags to improve performance

### How to review

- Check that the changes make sense
- Check SPAG for the documentation

### Who can review

Anyone
