### PR TITLE
Updated $jaffa-orange colour value to #FE781F for improved contrast.

### DIFF
--- a/src/scss/abstracts/variables/_colors.scss
+++ b/src/scss/abstracts/variables/_colors.scss
@@ -15,7 +15,7 @@ $flamingo-pink: #DF0667;
 
 // --- Supporting palette ---
 $ruby-red: #D0021B;
-$jaffa-orange: #FE781F;
+$jaffa-orange: #FA6401;
 $sun-yellow: #FBC900;
 $neon-yellow: #F0F762;
 $leaf-green: #0F8243;

--- a/src/views/data/colours.js
+++ b/src/views/data/colours.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   supporting: {
     'ruby-red': '#D0021B',
-    'jaffa-orange': '#FE781F',
+    'jaffa-orange': '#FA6401',
     'sun-yellow': '#FBC900',
     'neon-yellow': '#F0F762',
     'leaf-green': '#0F8243',


### PR DESCRIPTION
### What

Updated the `$jaffa-orange` to `#FA6401` from `#FE781F` to improve contrast on white.

Fixes #21 

### How to review

Check that no references to old colour value exist and that documentation has been updated.

### Who can review

Anyone but me.