### PR TITLE
Amending styling for radios without border

### DIFF
--- a/src/scss/base/utilities/_margin.scss
+++ b/src/scss/base/utilities/_margin.scss
@@ -1,0 +1,24 @@
+$sizes: (
+  no: 0,
+  xs: 0.5rem,
+  s: 1rem,
+  m: 1.5rem,
+  l: 2rem,
+  xl: 3rem,
+);
+
+$margins: (
+  mt: margin-top,
+  mr: margin-right,
+  mb: margin-bottom,
+  ml: margin-left,
+  m: margin,
+);
+
+@each $key, $value in $sizes {
+    @each $abbr, $dec in $margins {
+      .dp-#{$abbr}-#{$key} {
+        #{$dec}: #{$value} !important;
+      }
+    }
+  }

--- a/src/scss/components/_fieldset.scss
+++ b/src/scss/components/_fieldset.scss
@@ -7,7 +7,7 @@
       color: inherit;
       display: block;
       font-weight: $font-weight-bold;
-      margin-bottom: 0.4rem;
+      margin-bottom: 1rem;
   
       &__description {  
         display: inline-block;

--- a/src/scss/components/_radios.scss
+++ b/src/scss/components/_radios.scss
@@ -120,7 +120,7 @@ label.dp-label--with-description {
     display: block;
   }
 
-  &__item {
+  &__item, &__item--no-border {
     display: inline-block;
     margin: 0 0 0.5rem;
     width: 100%;
@@ -133,6 +133,10 @@ label.dp-label--with-description {
       min-width: 20rem;
       width: auto;
     }
+  }
+
+  &__item--no-border {
+    margin: 0 0 1rem;
   }
 
   &__label {

--- a/src/scss/components/_radios.scss
+++ b/src/scss/components/_radios.scss
@@ -7,7 +7,7 @@ $radio-padding: 0.6rem;
   width: 100%;
   z-index: 1;
 
-  &__input {
+  &__input, &__input--no-border {
     appearance: none;
     background: url("#{$static}/images/icons--check.svg") no-repeat center
       center;
@@ -29,7 +29,12 @@ $radio-padding: 0.6rem;
 
     &:checked {
       background: $black;
-    }  
+    } 
+    
+    &--no-border {
+      left: 0.05rem;
+      top: 0.15rem;
+    }
   }
 
   &__input:checked + &__label::before {
@@ -69,6 +74,10 @@ $radio-padding: 0.6rem;
     * {
       pointer-events: none;
     }
+  }
+
+  &__label--no-border {
+    padding: 0 0 0 ($radio-input-width + $radio-padding);
   }
 
   &__label--no-border::before {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -20,6 +20,7 @@ $static: '../';
 'base/fonts',
 'base/typography',
 'base/utilities/hide',
+'base/utilities/margin',
 'base/forms',
 'base/generic';
 

--- a/src/views/components/radios/index.njk
+++ b/src/views/components/radios/index.njk
@@ -56,7 +56,7 @@ eleventyNavigation:
   
   <h3 class="mb-4">Radios without a border</h3>
   <p>This variant removes the border surrounding the radio input and <a href="/components/label">label</a>.</p>
-  <p>Use the css class <code>dp-radio__input--no-border</code> on the input and <code>dp-radio__label--no-border</code> on the label.</p>
+  <p>Use the css class <code>dp-radios--item--no-border</code> on the radio item containing paragraph, use <code>dp-radio__input--no-border</code> on the input and <code>dp-radio__label--no-border</code> on the label.</p>
   {{ example({group: "components", item: "radios", example: "without-border", html: true, open: false }) }}
   
 </section>

--- a/src/views/components/radios/index.njk
+++ b/src/views/components/radios/index.njk
@@ -51,12 +51,12 @@ eleventyNavigation:
   {{ example({group: "components", item: "radios", example: "other--select", html: true, open: false }) }}
 
   <h3 class="mb-4">Radios with an ‘or’ label</h3>
-  <p>This variant has an 'or' label</p>
+  <p>This variant has an 'or' label.</p>
   {{ example({group: "components", item: "radios", example: "with-or", html: true, open: false }) }}
   
   <h3 class="mb-4">Radios without a border</h3>
-  <p>This variant removes the border surrounding the radio input and <a href="/components/label">label</a></p>
-  <p>Use the css class <code>dp-radio__label--no-border</code> on the label</p>
+  <p>This variant removes the border surrounding the radio input and <a href="/components/label">label</a>.</p>
+  <p>Use the css class <code>dp-radio__input--no-border</code> on the input and <code>dp-radio__label--no-border</code> on the label.</p>
   {{ example({group: "components", item: "radios", example: "without-border", html: true, open: false }) }}
   
 </section>

--- a/src/views/components/radios/without-border/index.njk
+++ b/src/views/components/radios/without-border/index.njk
@@ -8,14 +8,14 @@ layout: example
     <fieldset class="dp-fieldset">
         <legend class="dp-fieldset__legend">Select your favourite topping</legend>
         <div class="dp-radios__items">
-            <p class="dp-radios__item">
+            <p class="dp-radios__item--no-border">
                 <span class="dp-radio">
                     <input type="radio" id="bacon" class="dp-radio__input--no-border" value="bacon" name="food">
                     <label class="dp-radio__label--no-border" for="bacon" id="bacon-label">Bacon</label>
                 </span>
             </p>
             <br>
-            <p class="dp-radios__item">
+            <p class="dp-radios__item--no-border">
                 <span class="dp-radio">
                     <input type="radio" id="olives" class="dp-radio__input--no-border" value="olives" name="food">
                     <label class="dp-radio__label--no-border" for="olives" id="olives-label">Olives</label>

--- a/src/views/components/radios/without-border/index.njk
+++ b/src/views/components/radios/without-border/index.njk
@@ -10,14 +10,14 @@ layout: example
         <div class="dp-radios__items">
             <p class="dp-radios__item">
                 <span class="dp-radio">
-                    <input type="radio" id="bacon" class="dp-radio__input" value="bacon" name="food">
+                    <input type="radio" id="bacon" class="dp-radio__input--no-border" value="bacon" name="food">
                     <label class="dp-radio__label--no-border" for="bacon" id="bacon-label">Bacon</label>
                 </span>
             </p>
             <br>
             <p class="dp-radios__item">
                 <span class="dp-radio">
-                    <input type="radio" id="olives" class="dp-radio__input" value="olives" name="food">
+                    <input type="radio" id="olives" class="dp-radio__input--no-border" value="olives" name="food">
                     <label class="dp-radio__label--no-border" for="olives" id="olives-label">Olives</label>
                 </span>
             </p>


### PR DESCRIPTION
### What

- Removed padding/spacing inheritance from variant with a border
- Added spacing between the legend and content
- Added margin utility class

_before_
<img width="1074" alt="Screenshot 2021-07-05 at 08 57 38" src="https://user-images.githubusercontent.com/19624419/124437798-57dad680-dd6f-11eb-9586-8d6c36be0dd4.png">

_after_
![Screenshot 2021-08-05 at 10 09 55](https://user-images.githubusercontent.com/19624419/128324495-3390cadd-5af3-40d2-a0a1-4e1f7b4b5988.png)

### How to review

- Pull local branch
- Run
- Check spelling
- Sense check

### Who can review

Anyone but me
