### PR TITLE
Feature/port header footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When PRs are merged into `main`, compiled assets are made available on the ONS C
 
 ## Configuration
 
-Locally served on port 9001
+Locally served on port 9002
 .sass-lint
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
       }
     },
     "@ons/design-system": {
-      "version": "41.0.2",
-      "resolved": "https://registry.npmjs.org/@ons/design-system/-/design-system-41.0.2.tgz",
-      "integrity": "sha512-cp96btKmBOZEATsaNoJtsHdBqvWc7pZdjz3QriqaVjMIMs6ODS0cGOK04cXhgG+QqN002Pvg8xNAUKo1TzD3BQ=="
+      "version": "42.2.0",
+      "resolved": "https://registry.npmjs.org/@ons/design-system/-/design-system-42.2.0.tgz",
+      "integrity": "sha512-hhKvqRXa67LooOJ8Sgq6/8ma0k6gCrHbZhQFUrpI76n2vLlbKMq1n6Q3o+Ors2HhVUtCo7cvPWZFuspRe+RXjw=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/ONSdigital/dp-design-system#readme",
   "dependencies": {
-    "@ons/design-system": "^41.0.2",
+    "@ons/design-system": "^42.2.0",
     "core-js": "^3.18.3",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "audit": "auditjs ossi --quiet",
     "build": "npm run clean && NODE_ENV=production gulp build",
     "watch": "gulp watch",
-    "server": "ws -p ${PORT:-9001}",
+    "server": "ws -p ${PORT:-9002}",
     "dev": "run-p clean watch server",
     "clean": "rimraf ./dist"
   },

--- a/src/js/dp/improve-this-page.js
+++ b/src/js/dp/improve-this-page.js
@@ -1,0 +1,169 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const pageURL = window.location.href;
+  const feedbackURL = "/feedback";
+  const feedbackFormHeader = document.querySelector("#feedback-form-header");
+  const feedbackMessage =
+    '<span id="feedback-form-confirmation">Thank you. Your feedback will help us as we continue to improve the service.</span>';
+  const feedbackMessageError =
+    '<span id="feedback-form-error role="alert"">Something went wrong, try using our <a href="/feedback">feedback form</a>.</span>';
+
+  const feedbackFormURL = document.querySelector("#feedback-form-url");
+  if (feedbackFormURL) {
+    feedbackFormURL.value = pageURL;
+  }
+
+  const feedbackToggles = document.querySelectorAll("a.js-toggle");
+  if (feedbackToggles) {
+    feedbackToggles.forEach((toggle) => {
+      toggle.addEventListener("click", function (e) {
+        e.preventDefault();
+        const feedbackForm = document.querySelector("#feedback-form");
+        if (feedbackForm) {
+          feedbackForm.classList.toggle("js-hidden");
+        }
+        if (feedbackFormHeader) {
+          feedbackFormHeader.classList.toggle("js-hidden");
+        }
+        const id = toggle.id;
+        if (id !== "feedback-form-close") {
+          const descriptionField = document.querySelector("#description-field");
+          if (descriptionField) {
+            descriptionField.focus();
+          }
+        }
+      });
+    });
+  }
+
+  const feedbackFormYes = document.querySelector("#feedback-form-yes");
+  if (feedbackFormYes && feedbackFormHeader) {
+    feedbackFormYes.addEventListener("click", function (e) {
+      e.preventDefault();
+      const feedbackFormContainer = document.querySelector(
+        "#feedback-form-container"
+      );
+
+      const serializedData = serializeFormData(feedbackFormContainer);
+      const request = new XMLHttpRequest();
+      request.open("POST", `${feedbackURL}/positive`, true);
+      request.setRequestHeader(
+        "Content-Type",
+        "application/x-www-form-urlencoded; charset=UTF-8"
+      );
+      request.onreadystatechange = function () {
+        if (request.readyState === XMLHttpRequest.DONE) {
+          const status = request.status;
+          if (status === 0 || (status >= 200 && status < 400)) {
+            feedbackFormHeader.innerHTML = feedbackMessage;
+          } else {
+            console.error(
+              `footer feedback error: ${request.status}: ${request.statusText}`
+            );
+            feedbackFormHeader.innerHTML = feedbackMessageError;
+          }
+        }
+      };
+      request.send(serializedData);
+    });
+  }
+
+  const feedbackFormContainer = document.querySelector(
+    "#feedback-form-container"
+  );
+  if (feedbackFormContainer) {
+    feedbackFormContainer.addEventListener("submit", function (e) {
+      e.preventDefault();
+      const fieldErrors = document.querySelectorAll(
+        "#feedback-form-container .form-control__error"
+      );
+      fieldErrors.forEach((fieldError) => {
+        fieldError.classList.remove("form-control__error");
+      });
+
+      const formErrors = document.querySelectorAll(
+        "#feedback-form-container .form-error"
+      );
+      formErrors.forEach((formError) => {
+        formError.remove();
+      });
+
+      const emailField = document.querySelector("#email-field");
+      const descriptionField = document.querySelector("#description-field");
+      let hasErrors = false;
+
+      if (descriptionField && descriptionField.value === "") {
+        const descriptionError =
+          '<span class="form-error" role="alert">Write some feedback</span>';
+        if (!document.querySelector("#description-field-label .form-error")) {
+          const descriptionFieldLabel = document.querySelector(
+            "#description-field-label"
+          );
+          descriptionFieldLabel.insertAdjacentHTML(
+            "beforeend",
+            descriptionError
+          );
+        }
+        descriptionField.classList.add("form-control__error");
+        hasErrors = true;
+      }
+
+      if (emailField && emailField.value !== "") {
+        let emailError = "";
+        if (hasErrors) {
+          emailError =
+            '<span class="form-error" role="alert" aria-live="polite">This is not a valid email address, correct it or delete it</span>';
+        } else {
+          emailError =
+            '<span class="form-error" role="alert">This is not a valid email address, correct it or delete it</span>';
+        }
+
+        const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/g;
+        if (!emailRegex.test(emailField.value)) {
+          if (!document.querySelector("#email-field-label .form-error")) {
+            const emailFieldLabel =
+              document.querySelector("#email-field-label");
+            emailFieldLabel.insertAdjacentHTML("beforeend", emailError);
+          }
+          hasErrors = true;
+        }
+      }
+
+      if (hasErrors) {
+        return;
+      }
+
+      const serializedData = serializeFormData(feedbackFormContainer);
+      const request = new XMLHttpRequest();
+      request.open("POST", feedbackURL, true);
+      request.setRequestHeader(
+        "Content-Type",
+        "application/x-www-form-urlencoded; charset=UTF-8"
+      );
+      request.onreadystatechange = function () {
+        if (request.readyState === XMLHttpRequest.DONE) {
+          const status = request.status;
+          if (status === 0 || (status >= 200 && status < 400)) {
+            feedbackFormHeader.innerHTML = feedbackMessage;
+          } else {
+            console.error(
+              `footer feedback error: ${request.status}: ${request.statusText}`
+            );
+            feedbackFormHeader.innerHTML = feedbackMessageError;
+          }
+        }
+      };
+      const feedbackForm = document.querySelector("#feedback-form");
+      if (feedbackForm) {
+        feedbackForm.classList.add("js-hidden");
+      }
+      feedbackFormHeader.classList.toggle("js-hidden");
+      request.send(serializedData);
+    });
+  }
+});
+
+function serializeFormData(form) {
+  const data = new FormData(form);
+  const serializedData = new URLSearchParams(data).toString();
+  return serializedData;
+}

--- a/src/js/dp/improve-this-page.js
+++ b/src/js/dp/improve-this-page.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
   const pageURL = window.location.href;
-  const feedbackURL = "/feedback";
+  const feedbackPath = "/feedback";
+  const positiveFeedbackPath = `${feedbackPath}/positive`;
   const feedbackFormHeader = document.querySelector("#feedback-form-header");
   const feedbackMessage =
     '<span id="feedback-form-confirmation">Thank you. Your feedback will help us as we continue to improve the service.</span>';
@@ -43,26 +44,7 @@ document.addEventListener("DOMContentLoaded", function () {
         "#feedback-form-container"
       );
 
-      const serializedData = serializeFormData(feedbackFormContainer);
-      const request = new XMLHttpRequest();
-      request.open("POST", `${feedbackURL}/positive`, true);
-      request.setRequestHeader(
-        "Content-Type",
-        "application/x-www-form-urlencoded; charset=UTF-8"
-      );
-      request.onreadystatechange = function () {
-        if (request.readyState === XMLHttpRequest.DONE) {
-          const status = request.status;
-          if (status === 0 || (status >= 200 && status < 400)) {
-            feedbackFormHeader.innerHTML = feedbackMessage;
-          } else {
-            console.error(
-              `footer feedback error: ${request.status}: ${request.statusText}`
-            );
-            feedbackFormHeader.innerHTML = feedbackMessageError;
-          }
-        }
-      };
+      const { request, serializedData } = initFeedbackRequestHandler(feedbackFormContainer, positiveFeedbackPath, feedbackFormHeader, feedbackMessage, feedbackMessageError);
       request.send(serializedData);
     });
   }
@@ -132,26 +114,7 @@ document.addEventListener("DOMContentLoaded", function () {
         return;
       }
 
-      const serializedData = serializeFormData(feedbackFormContainer);
-      const request = new XMLHttpRequest();
-      request.open("POST", feedbackURL, true);
-      request.setRequestHeader(
-        "Content-Type",
-        "application/x-www-form-urlencoded; charset=UTF-8"
-      );
-      request.onreadystatechange = function () {
-        if (request.readyState === XMLHttpRequest.DONE) {
-          const status = request.status;
-          if (status === 0 || (status >= 200 && status < 400)) {
-            feedbackFormHeader.innerHTML = feedbackMessage;
-          } else {
-            console.error(
-              `footer feedback error: ${request.status}: ${request.statusText}`
-            );
-            feedbackFormHeader.innerHTML = feedbackMessageError;
-          }
-        }
-      };
+      const { request, serializedData } = initFeedbackRequestHandler(feedbackFormContainer, feedbackPath, feedbackFormHeader, feedbackMessage, feedbackMessageError);
       const feedbackForm = document.querySelector("#feedback-form");
       if (feedbackForm) {
         feedbackForm.classList.add("js-hidden");
@@ -161,6 +124,30 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 });
+
+function initFeedbackRequestHandler(form, path, feedbackFormHeader, feedbackMessage, feedbackMessageError) {
+  const serializedData = serializeFormData(form);
+  const request = new XMLHttpRequest();
+  request.open("POST", path, true);
+  request.setRequestHeader(
+    "Content-Type",
+    "application/x-www-form-urlencoded; charset=UTF-8"
+  );
+  request.onreadystatechange = function () {
+    if (request.readyState === XMLHttpRequest.DONE) {
+      const status = request.status;
+      if (status === 0 || (status >= 200 && status < 400)) {
+        feedbackFormHeader.innerHTML = feedbackMessage;
+      } else {
+        console.error(
+          `footer feedback error: ${request.status}: ${request.statusText}`
+        );
+        feedbackFormHeader.innerHTML = feedbackMessageError;
+      }
+    }
+  };
+  return { request, serializedData };
+}
 
 function serializeFormData(form) {
   const data = new FormData(form);

--- a/src/js/dp/nav.js
+++ b/src/js/dp/nav.js
@@ -1,0 +1,277 @@
+function toggleSubnav(element) {
+  element.classList.toggle("js-expandable-active");
+  element.querySelectorAll(".js-expandable__content").forEach((el) => {
+    el.classList.toggle("js-nav-hidden");
+  });
+
+  const elementAria = getBoolFromString(element.querySelector("a:first-child").ariaExpanded)
+  element.querySelector("a:first-child").ariaExpanded = !elementAria;
+  const subnavAria = getBoolFromString(element.querySelector(".js-expandable__content").ariaExpanded)
+  element.querySelector(".js-expandable__content").ariaExpanded = !subnavAria
+}
+
+function toggleMenu(toggleElement, menuElement) {
+  toggleElement.classList.toggle("menu-is-expanded");
+  const toggleAriaState = getBoolFromString(
+    toggleElement.querySelector("a").ariaExpanded
+  );
+  toggleElement.querySelector("a").ariaExpanded = !toggleAriaState;
+  menuElement.classList.toggle("nav-main--hidden");
+  const menuAriaState = getBoolFromString(menuElement.ariaExpanded);
+  menuElement.ariaExpanded = !menuAriaState;
+}
+
+function getBoolFromString(stringToConvert) {
+  return (stringToConvert == "true") ? true : false;
+}
+
+function toggleSearch(toggleElement, searchElement) {
+  const langAttribute = document.documentElement.lang;
+  toggleElement.classList.toggle("search-is-expanded");
+  const toggleAriaState = getBoolFromString(
+    toggleElement.querySelector("a").ariaExpanded
+  );
+  toggleElement.querySelector("a").ariaExpanded = !toggleAriaState;
+  let searchStr = "";
+  if (langAttribute == "en") {
+    toggleElement
+      .querySelector(".nav--controls__text")
+      .textContent.includes("Hide")
+      ? (searchStr = "Search")
+      : (searchStr = "Hide search");
+  } else {
+    toggleElement
+      .querySelector(".nav--controls__text")
+      .textContent.includes("Cuddio")
+      ? (searchStr = "Chwilio")
+      : (searchStr = "Cuddio");
+  }
+  toggleElement.querySelector(".nav--controls__text").textContent = searchStr;
+  searchElement.classList.toggle("nav-search--hidden");
+  const searchAriaState = getBoolFromString(searchElement.ariaExpanded);
+  searchElement.ariaExpanded = !searchAriaState;
+}
+
+function cloneSecondaryNav() {
+  // On mobile move secondary nav items in header to primary nav
+  const navLink = document.querySelectorAll(".js-nav-clone__link");
+  const navList = document.querySelector(".js-nav-clone__list");
+
+  if (
+    document.body.classList.contains("viewport-sm") &&
+    navList.querySelectorAll(".js-nav-clone__link").length > 0
+  ) {
+    // Remove from separate UL and add into primary
+    navLink.forEach((link) => {
+      link.parentNode.style.display = "none";
+      const newNavItem = document.createElement("li");
+      newNavItem.classList.add("primary-nav__item");
+
+      link.classList.remove("secondary-nav__link");
+      link.classList.add("primary-nav__link", "col");
+
+      newNavItem.insertAdjacentElement("beforeend", link);
+
+      const primaryNavList = document.querySelector(
+        ".primary-nav__list li.primary-nav__language"
+      );
+      primaryNavList.insertAdjacentElement("beforebegin", newNavItem);
+    });
+  } else if (
+    !document.body.classList.contains("viewport-sm") &&
+    document.querySelector(".secondary-nav__item").style.display === "none"
+  ) {
+    // Remove from primary nav and add into separate secondary list
+    navLink.forEach((link, i) => {
+      let index = i + 1;
+      link.classList.add("secondary-nav__link");
+      link.classList.remove("primary-nav__link", "col");
+      link.parentNode.remove();
+      const cloneList = document.querySelector(
+        `.js-nav-clone__list li:nth-child(${index})`
+      );
+      cloneList.insertAdjacentElement("beforeend", link);
+      link.parentNode.style.display = "block";
+    });
+  }
+}
+
+function clonePrimaryItems() {
+  const detectDuplicate = document.querySelectorAll(".js-nav__duplicate");
+  const expandableList = document.querySelectorAll(".js-expandable");
+
+  // Clone primary nav items into sub-menu on mobile, so it can still be selected on mobile
+  if (
+    document.body.classList.contains("viewport-sm") &&
+    detectDuplicate.length === 0
+  ) {
+    expandableList.forEach((item) => {
+      const href = item.querySelector("a").getAttribute("href");
+      const text = item.querySelector(".submenu-title").innerText;
+      const childList = item.querySelector(".js-expandable__content");
+
+      const newLink = document.createElement("a");
+      newLink.classList.add("primary-nav__child-link");
+      newLink.href = href;
+      newLink.innerText = text.trim();
+
+      const newItem = document.createElement("li");
+      newItem.classList.add(
+        "primary-nav__child-item",
+        "js-nav__duplicate",
+        "js-expandable__child"
+      );
+      newItem.insertAdjacentElement("beforeend", newLink);
+      childList.insertBefore(newItem, childList.firstChild);
+    });
+  } else if (
+    !document.body.classList.contains("viewport-sm") &&
+    detectDuplicate.length > 0
+  ) {
+    detectDuplicate.forEach((duplicate) => {
+      duplicate.remove();
+    });
+  }
+}
+
+window.addEventListener("resize", function () {
+  clonePrimaryItems();
+  cloneSecondaryNav();
+});
+
+document.addEventListener("DOMContentLoaded", function () {
+  const primaryNav = document.querySelector("#nav-primary");
+  const searchBar = document.querySelector("#searchBar");
+  const navItem = document.querySelectorAll(".js-nav");
+  const expandableItems = document.querySelectorAll(".js-expandable");
+
+  clonePrimaryItems();
+  cloneSecondaryNav();
+
+  primaryNav.classList.add("nav-main--hidden");
+  primaryNav.ariaExpanded = false;
+
+  expandableItems.forEach((item) => {
+    item.addEventListener("click", function (event) {
+      if (document.body.classList.contains("viewport-sm")) {
+        event.preventDefault();
+        toggleSubnav(this);
+      }
+    });
+  });
+
+  // stop parent element from taking over all click events
+  document
+    .querySelectorAll(".js-expandable > .js-expandable__content")
+    .forEach((elem) => {
+      elem.addEventListener("click", function (event) {
+        event.stopPropagation();
+      });
+    });
+
+  navItem.forEach((item) => {
+    item.addEventListener("keydown", function (e) {
+      const focusedItem = document.querySelector(
+          ".js-expandable__child a:focus"
+        ), // only selects child item that is in focus
+        keycode = e.keyCode,
+        up = "38",
+        down = "40",
+        right = "39",
+        left = "37",
+        esc = "27",
+        tab = "9";
+      if (keycode == tab && focusedItem) {
+        item.classList.remove("primary-nav__item--focus");
+        item.nextElementSibling.focus();
+      }
+      if (keycode == esc) {
+        item.classList.remove("primary-nav__item--focus");
+        const closestNav = item.closest(".js-nav");
+        const link = closestNav.querySelector("a");
+        link.classList.add("hide-children");
+        link.focus();
+        link.addEventListener("focusout", function () {
+          link.classList.remove("hide-children");
+        });
+      }
+      if (keycode == down) {
+        e.preventDefault();
+        item.classList.add("primary-nav__item--focus");
+        if (focusedItem) {
+          focusedItem.parentElement.nextElementSibling
+            .querySelector("a")
+            .focus();
+        } else {
+          item.querySelector(".js-expandable__child a").focus();
+        }
+      }
+      if (keycode == up) {
+        e.preventDefault();
+        if (focusedItem && focusedItem.parentElement.previousElementSibling) {
+          focusedItem.parentElement.previousElementSibling
+            .querySelector("a")
+            .focus();
+        } else {
+          item.classList.remove("primary-nav__item--focus");
+          item.querySelector("a").focus();
+        }
+      }
+      if (keycode == right) {
+        e.preventDefault();
+        item.classList.remove("primary-nav__item--focus");
+        const closestNav = item.closest(".js-nav");
+        closestNav.nextElementSibling.querySelector("a").focus();
+      }
+      if (keycode == left) {
+        e.preventDefault();
+        item.classList.remove("primary-nav__item--focus");
+        const closestNav = item.closest(".js-nav");
+        closestNav.previousElementSibling.querySelector("a").focus();
+      }
+    });
+  });
+
+  expandableItems.forEach((item) => {
+    item.addEventListener("pointerenter", function (e) {
+      if (!document.body.classList.contains("viewport-sm")) {
+        const navLink = item.querySelector(".primary-nav__link");
+        navLink.ariaExpanded = true;
+        const expandable = item.querySelector(".js-expandable__content");
+        expandable.ariaExpanded = true;
+      }
+    });
+  });
+
+  expandableItems.forEach((item) => {
+    item.addEventListener("pointerleave", function (e) {
+      if (!document.body.classList.contains("viewport-sm")) {
+        const navLink = item.querySelector(".primary-nav__link");
+        navLink.ariaExpanded = false;
+        const expandable = item.querySelector(".js-expandable__content");
+        expandable.ariaExpanded = false;
+      }
+    });
+  });
+
+  const menuToggle = document.querySelector("#menu-toggle");
+  const menuToggleContainer = menuToggle.parentNode;
+  const searchToggle = document.querySelector("#search-toggle");
+  const searchToggleContainer = searchToggle.parentNode;
+
+  menuToggle.addEventListener("click", function (event) {
+    event.preventDefault();
+    if (!searchBar.classList.contains("nav-search--hidden")) {
+      toggleSearch(searchToggleContainer, searchBar);
+    } 
+    toggleMenu(menuToggleContainer, primaryNav);
+  });
+
+  searchToggle.addEventListener("click", function (event) {
+    event.preventDefault();
+    if (!primaryNav.classList.contains("nav-main--hidden")) {
+      toggleMenu(menuToggleContainer, primaryNav);
+    }
+    toggleSearch(searchToggleContainer, searchBar);
+  });
+});

--- a/src/js/dp/viewport-size.js
+++ b/src/js/dp/viewport-size.js
@@ -1,0 +1,37 @@
+function initViewportSize() {
+  const footers = document.querySelector("footer");
+  if (footers) {
+    // Get the last one expected to be the main one for the page
+    const viewportDivHTML =
+      "<div id='viewport-sm' class='js-viewport-size'></div>" +
+      "<div id='viewport-md' class='js-viewport-size'></div>" +
+      "<div id='viewport-lg' class='js-viewport-size'></div>";
+
+    footers.insertAdjacentHTML("beforeend", viewportDivHTML);
+
+    jsEnhanceViewportSize();
+  }
+}
+
+window.addEventListener("resize", function () {
+  jsEnhanceViewportSize();
+});
+
+function clearViewportSizes() {
+  document.body.classList.remove("viewport-sm", "viewport-md", "viewport-lg");
+}
+
+function jsEnhanceViewportSize() {
+  const viewportDivs = document.querySelectorAll(".js-viewport-size");
+  if (viewportDivs) {
+    viewportDivs.forEach((div) => {
+      if (window.getComputedStyle(div).display === "block") {
+        clearViewportSizes();
+        const idName = div.id;
+        document.body.classList.add(idName);
+      }
+    });
+  }
+}
+
+document.addEventListener("DOMContentLoaded", initViewportSize);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,8 @@
-import '@ons/design-system/scripts/main'
+import "@ons/design-system/scripts/main";
 
 // DP-specific JS
-import './dp/cookies-banner'
-import './dp/set-display'
+import "./dp/cookies-banner";
+import "./dp/set-display";
+import "./dp/viewport-size";
+import "./dp/nav";
+import "./dp/improve-this-page";

--- a/src/js/polyfills.js
+++ b/src/js/polyfills.js
@@ -1,5 +1,5 @@
 // Import polyfills for IE11
-import 'core-js/stable'
+import 'core-js'
 import 'mdn-polyfills/CustomEvent'
 import 'mdn-polyfills/Node.prototype.append'
 import 'mdn-polyfills/Node.prototype.remove'

--- a/src/scss/dp/_styles.scss
+++ b/src/scss/dp/_styles.scss
@@ -8,4 +8,7 @@
 @import './overrides/helpers/margins';
 
 @import './overrides/components/button';
+@import './overrides/components/nav';
 @import './overrides/components/cookies-banner';
+@import './overrides/components/language-toggle';
+@import './overrides/components/header';

--- a/src/scss/dp/_styles.scss
+++ b/src/scss/dp/_styles.scss
@@ -12,3 +12,6 @@
 @import './overrides/components/cookies-banner';
 @import './overrides/components/language-toggle';
 @import './overrides/components/header';
+@import './overrides/components/search-bar';
+@import './overrides/components/footer';
+@import './overrides/components/improve-this-page';

--- a/src/scss/dp/overrides/base/_grid.scss
+++ b/src/scss/dp/overrides/base/_grid.scss
@@ -1,13 +1,9 @@
 //_grid.scss
 
-
 //--[vars]--
-
-// $baseline: 16px;
 
 $col: 16px;
 $gutter: 16px;
-
 
 $large-complex-grid-cols: 59;
 $medium-complex-grid-cols: 47;
@@ -19,23 +15,21 @@ $medium: $medium-complex-grid-cols * $col;
 $large-cols-one: $large-complex-grid-cols * $col;
 $large-cols-half: (($large-complex-grid-cols - 1) / 2) * $col;
 $large-cols-one-third: (($large-complex-grid-cols - 2) / 3) * $col;
-$large-cols-two-thirds: (($large-complex-grid-cols - 1) * $col) - $large-cols-one-third;
+$large-cols-two-thirds: (($large-complex-grid-cols - 1) * $col) -
+  $large-cols-one-third;
 $large-cols-one-quarter: (($large-complex-grid-cols - 3) / 4) * $col;
-$large-cols-three-quarters: (($large-complex-grid-cols - 1) * $col) - $large-cols-one-quarter;
+$large-cols-three-quarters: (($large-complex-grid-cols - 1) * $col) -
+  $large-cols-one-quarter;
 
 $medium-cols-one: $medium-complex-grid-cols * $col;
 $medium-cols-half: (($medium-complex-grid-cols - 1) / 2) * $col;
 $medium-cols-one-third: (($medium-complex-grid-cols - 2) / 3) * $col;
-$medium-cols-two-thirds: (($medium-complex-grid-cols - 1) * $col )- $medium-cols-one-third;
+$medium-cols-two-thirds: (($medium-complex-grid-cols - 1) * $col)- $medium-cols-one-third;
 $medium-cols-one-quarter: (($medium-complex-grid-cols - 3) / 4) * $col;
-$medium-cols-three-quarters: (($medium-complex-grid-cols - 1) * $col) - $medium-cols-one-quarter;
+$medium-cols-three-quarters: (($medium-complex-grid-cols - 1) * $col) -
+  $medium-cols-one-quarter;
 
 //--[vars end]--
-
-
-
-
-
 
 //--[mixins]--
 
@@ -43,264 +37,201 @@ $medium-cols-three-quarters: (($medium-complex-grid-cols - 1) * $col) - $medium-
 
 // Generate the large columns
 @mixin make-lg-column($columns) {
-	position: relative;
-	min-height: 1px;
-	margin-left:  ($gutter);
-	float: left;
-
-	// @media (min-width: $screen-md-min) {
-	// 	float: left;
-	// 	width: percentage(($columns / $grid-columns));
-	// }
+  position: relative;
+  min-height: 1px;
+  margin-left: ($gutter);
+  float: left;
 }
-
 
 @mixin large-cols-complex {
   @for $i from 1 through $large-complex-grid-cols {
-  &--lg-#{$i} {
-  	width: $col * $i;
-  	margin: 0;
-   }
+    &--lg-#{$i} {
+      width: $col * $i;
+      margin: 0;
+    }
   }
 }
 
-
 @mixin medium-cols-complex {
   @for $i from 1 through $medium-complex-grid-cols {
-  &--md-#{$i} {
-  	width: $col * $i;
-  	margin: 0;
+    &--md-#{$i} {
+      width: $col * $i;
+      margin: 0;
+    }
   }
- }
 }
 
 @mixin large-cols-offset {
   @for $i from 1 through $large-complex-grid-cols {
-  &--lg-offset-#{$i} {
-  	margin-left: $col * $i;
-   }
+    &--lg-offset-#{$i} {
+      margin-left: $col * $i;
+    }
   }
 }
 
 @mixin medium-cols-offset {
   @for $i from 1 through $medium-complex-grid-cols {
-  &--md-offset-#{$i} {
-  	margin-left: $col * $i;
-   }
+    &--md-offset-#{$i} {
+      margin-left: $col * $i;
+    }
   }
 }
 
 //--[mixins end]--
 
-
-
-
-
-
 //--[classes]--
 .wrapper {
-	// overflow: hidden;
-	@extend %clearfix;
-	@extend .ons-container;
-	// width: 100%;
-	// margin:0 auto;
-	// padding: 0 16px;
-
-	// @include breakpoint(md) {
-	// 	width: ($medium);
-	// 	padding: 0;
-	// }
-
-	// @include breakpoint(lg) {
-	// 	width: ($large);
-	// 	padding: 0;
-	// }
+  @extend %clearfix;
+  @extend .ons-container;
 }
 
-
-.col-wrap{
-	// overflow: hidden;
-	@extend %clearfix;
-	width: 100%;
-
-
-	@include breakpoint(md) {
-		width: ($medium + $gutter);
-		margin-left: -$gutter;
-	}
-
-	@include breakpoint(lg) {
-		width: ($large + $gutter);
-		margin-left: -$gutter;
-	}
-
-	@include breakpoint(md-max) {
-		width: 100%;
-		margin-left: -($gutter / 2);
-	}
-
+.col-wrap {
+  @extend %clearfix;
+  width: 100%;
 }
 
 .col-span {
-	&--lg {
-		@include breakpoint(lg) {
-			&-thirds {
-				.col {
-					&:nth-child(3n+4) {
-	      				clear: left;
-	      			}
-	  			}
-			}
-			&-half {
-				.col {
-					&:nth-child(2n+3) {
-						clear:left;
-					}
-				}
-			}
-		}
-	}
+  &--lg {
+    @include breakpoint(lg) {
+      &-thirds {
+        .col {
+          &:nth-child(3n + 4) {
+            clear: left;
+          }
+        }
+      }
+      &-half {
+        .col {
+          &:nth-child(2n + 3) {
+            clear: left;
+          }
+        }
+      }
+    }
+  }
 
-	&--md {
-		@include breakpoint(md) {
-			&-thirds {
-				.col {
-					&:nth-child(3n+4) {
-	      				clear: left;
-	      			}
-	  			}
-			}
-			&-half {
-				.col {
-					&:nth-child(2n+3) {
-						clear:left;
-					}
-				}
-			}
-		}
-	}
+  &--md {
+    @include breakpoint(md) {
+      &-thirds {
+        .col {
+          &:nth-child(3n + 4) {
+            clear: left;
+          }
+        }
+      }
+      &-half {
+        .col {
+          &:nth-child(2n + 3) {
+            clear: left;
+          }
+        }
+      }
+    }
+  }
 }
-
 
 .col {
-	// overflow: hidden;
-	@extend %clearfix;
-	width: 100%;
-	//padding-left: $gutter;
-	//padding-right: $gutter;
-	// box-sizing: border-box;
-	float: left;
+  @extend %clearfix;
+  width: 100%;
+  float: left;
 
-	@include breakpoint(md) {
-		width: ($medium);
-		margin-left: $gutter;
-		margin-right: 0;
-		// padding-left: 0;
-		// padding-right: 0;
+  @include breakpoint(md) {
+    width: ($medium);
+    margin-right: 0;
 
-		&--md {
-			&-one {
-				width: $medium-cols-one;
-			}
-		}
+    &--md {
+      &-one {
+        width: $medium-cols-one;
+      }
+    }
 
-		&--md {
-			&-half {
-				width: $medium-cols-half;
-			}
-		}
+    &--md {
+      &-half {
+        width: $medium-cols-half;
+      }
+    }
 
-		&--md {
-			&-one-third {
-				width: $medium-cols-one-third;
-			}
-		}
+    &--md {
+      &-one-third {
+        width: $medium-cols-one-third;
+      }
+    }
 
-		&--md {
-			&-two-thirds {
-				width: $medium-cols-two-thirds;
-			}
-		}
+    &--md {
+      &-two-thirds {
+        width: $medium-cols-two-thirds;
+      }
+    }
 
-		&--md {
-			&-one-quarter {
-				width: $medium-cols-one-quarter;
-			}
-			&-three-quarters {
-				width: $medium-cols-three-quarters;
-			}
-		}
+    &--md {
+      &-one-quarter {
+        width: $medium-cols-one-quarter;
+      }
+      &-three-quarters {
+        width: $medium-cols-three-quarters;
+      }
+    }
 
-		&--md {
-			&-full-width {
-				width: 100%;
-				margin: 0;
-			}
-		}
+    &--md {
+      &-full-width {
+        width: 100%;
+        margin: 0;
+      }
+    }
 
-		//call complex cols last so the css gets generated last and they take precedence
-		@include medium-cols-complex;
-		@include medium-cols-offset;
+    //call complex cols last so the css gets generated last and they take precedence
+    @include medium-cols-complex;
+    @include medium-cols-offset;
+  }
 
-	}
+  @include breakpoint(lg) {
+    width: ($large);
+    margin-right: 0;
 
-	@include breakpoint(lg) {
-		width: ($large);
-		margin-left: $gutter;
-		margin-right: 0;
-		// padding-left: 0;
-		// padding-right: 0;
+    &--lg {
+      &-one {
+        width: $large-cols-one;
+      }
+    }
 
-		&--lg {
-			&-one {
-				width: $large-cols-one;
-			}
-		}
+    &--lg {
+      &-half {
+        width: $large-cols-half;
+      }
+    }
 
-		&--lg {
-			&-half {
-				width: $large-cols-half;
-			}
-		}
+    &--lg {
+      &-one-third {
+        width: $large-cols-one-third;
+      }
+    }
+    &--lg {
+      &-two-thirds {
+        width: $large-cols-two-thirds;
+      }
+    }
 
-		&--lg {
-			&-one-third {
-				width: $large-cols-one-third;
-			}
-		}
-		&--lg {
-			&-two-thirds {
-				width: $large-cols-two-thirds;
-			}
-		}
+    &--lg {
+      &-one-quarter {
+        width: $large-cols-one-quarter;
+      }
+      &-three-quarters {
+        width: $large-cols-three-quarters;
+      }
+    }
 
-		&--lg {
-			&-one-quarter {
-				width: $large-cols-one-quarter;
-			}
-			&-three-quarters {
-				width: $large-cols-three-quarters;
-			}
-		}
+    &--lg {
+      &-full-width {
+        width: 100%;
+        margin: 0;
+      }
+    }
 
-		&--lg {
-			&-full-width {
-				width: 100%;
-				margin: 0;
-			}
-		}
+    //call complex cols last so the css gets generated last and they take precedence
+    @include large-cols-complex;
+    @include large-cols-offset;
+  }
 
-
-		//call complex cols last so the css gets generated last and they take precedence
-		@include large-cols-complex;
-		@include large-cols-offset;
-
-	}
-
-
-
-	// &--padded { padding: $baseline $gutter; }
 }
-
 
 //--[classes end]--

--- a/src/scss/dp/overrides/base/_grid.scss
+++ b/src/scss/dp/overrides/base/_grid.scss
@@ -134,6 +134,10 @@ $medium-cols-three-quarters: (($medium-complex-grid-cols - 1) * $col) - $medium-
 		margin-left: -$gutter;
 	}
 
+	@include breakpoint(md-max) {
+		width: 100%;
+		margin-left: -($gutter / 2);
+	}
 
 }
 

--- a/src/scss/dp/overrides/base/_grid.scss
+++ b/src/scss/dp/overrides/base/_grid.scss
@@ -101,19 +101,20 @@ $medium-cols-three-quarters: (($medium-complex-grid-cols - 1) * $col) - $medium-
 .wrapper {
 	// overflow: hidden;
 	@extend %clearfix;
-	width: 100%;
-	margin:0 auto;
-	padding: 0 16px;
+	@extend .ons-container;
+	// width: 100%;
+	// margin:0 auto;
+	// padding: 0 16px;
 
-	@include breakpoint(md) {
-		width: ($medium);
-		padding: 0;
-	}
+	// @include breakpoint(md) {
+	// 	width: ($medium);
+	// 	padding: 0;
+	// }
 
-	@include breakpoint(lg) {
-		width: ($large);
-		padding: 0;
-	}
+	// @include breakpoint(lg) {
+	// 	width: ($large);
+	// 	padding: 0;
+	// }
 }
 
 

--- a/src/scss/dp/overrides/components/_footer.scss
+++ b/src/scss/dp/overrides/components/_footer.scss
@@ -1,5 +1,6 @@
 .footer {
-  background-color: $color-banner-bg;
+  background-color: $color-grey-100;
+  color: $white;
 
   &--sticky {
     bottom: 0;
@@ -7,12 +8,12 @@
   }
 
   a {
-    color: $color-text-banner-link;
+    color: $color-grey-5;
     text-decoration: underline;
 
     &:hover {
-      color: $color-text-banner-link-hover;
-      text-decoration: underline solid $color-text-banner-link-hover 2px;
+      color: $white;
+      text-decoration: underline solid $white 2px;
     }
   }
 
@@ -46,9 +47,11 @@
   .ons-footer__ogl-img {
     float: left;
     margin-right: 1rem;
+    fill: $white;
   }
 
   .ons-external-link .ons-svg-icon {
     margin-left: 0.5rem;
+    fill: $white;
   }
 }

--- a/src/scss/dp/overrides/components/_footer.scss
+++ b/src/scss/dp/overrides/components/_footer.scss
@@ -1,0 +1,54 @@
+.footer {
+  background-color: $color-banner-bg;
+
+  &--sticky {
+    bottom: 0;
+    width: 100%;
+  }
+
+  a {
+    color: $color-text-banner-link;
+    text-decoration: underline;
+
+    &:hover {
+      color: $color-text-banner-link-hover;
+      text-decoration: underline solid $color-text-banner-link-hover 2px;
+    }
+  }
+
+  &-nav {
+    &__heading {
+      margin-top: 2rem;
+      font-size: 18px;
+    }
+
+    &__list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    &__item {
+      margin: 0;
+      padding: 6px 0 2px 0;
+    }
+  }
+
+  &-license {
+    padding: 1.5rem 0 $col 0;
+
+    &__text {
+      display: inline-block;
+      vertical-align: super;
+    }
+  }
+
+  .ons-footer__ogl-img {
+    float: left;
+    margin-right: 1rem;
+  }
+
+  .ons-external-link .ons-svg-icon {
+    margin-left: 0.5rem;
+  }
+}

--- a/src/scss/dp/overrides/components/_header.scss
+++ b/src/scss/dp/overrides/components/_header.scss
@@ -3,430 +3,428 @@
 // PRIMARY NAVIGATION
 
 .primary-nav {
+  background-color: $abbey;
+  position: relative;
 
-    background-color: $abbey;
-    position: relative;
+  @include breakpoint(md) {
+    border-top: 1px solid $thunder;
+    border-bottom: 1px solid $thunder;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0 auto;
+    font-size: 14px;
+    display: flex;
+    align-items: stretch;
+
+    @include breakpoint(md-max) {
+      justify-content: center;
+      flex-wrap: nowrap;
+    }
+
+    @include breakpoint(sm) {
+      padding: 0 0 $baseline 0;
+      display: block;
+    }
+  }
+
+  &__item {
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    display: inline-block;
+
+    @include breakpoint(sm) {
+      height: $baseline * 6;
+      display: block;
+      padding-left: 16px;
+    }
 
     @include breakpoint(md) {
-        border-top: 1px solid $thunder;
-        border-bottom: 1px solid $thunder;
+      &:nth-child(6) a {
+        border-right: 1px solid $thunder;
+      }
     }
 
-    &__list {
-        list-style: none;
-        margin: 0 auto;
-        font-size: 0;
-        display: flex;
-        align-items: stretch;
-
-        @include breakpoint(sm) {
-            padding: 0 0 $baseline 0;
-            display: block;
-        }
-    }
-
-    &__item {
-        margin: 0;
-        padding: 0;
-        cursor: pointer;
-        display: inline-block;
-
-        @include breakpoint(sm) {
-            height: $baseline * 6;
-            display: block;
-            padding-left: 16px;
-        }
-
-        @include breakpoint(md) {
-            &:nth-child(6) a {
-                border-right: 1px solid $thunder;
-            }
-        }
-
-        //children show on hover
-        &:hover > ul,
-        &--focus > ul {
-            top: 100%;
-            @include breakpoint(md) {
-                background-color: $thunder;
-                color: $white;
-                text-decoration: none;
-                display: block;
-            }
-        }
-
-        //set hover styling - done on link so it works on keyboard tab
-        &:hover > a,
-        &:focus > a,
-        &--focus > a {
-            @include breakpoint(md) {
-                border-left: 1px solid $thunder;
-                background-color: $thunder;
-                color: $white;
-                text-decoration: none;
-            }
-        }
-
-        &--active {
-            @include breakpoint(sm) {
-                & > a {
-                    background-color: $active;
-                }
-            }
-
-            @include breakpoint(md) {
-                background-color: $active;
-            }
-
-            & > a {
-                color: $white;
-            }
-        }
-
-    }
-
-    &__link {
-        color: $iron-light;
+    //children show on hover
+    &:hover > ul,
+    &--focus > ul {
+      top: 100%;
+      @include breakpoint(md) {
+        background-color: $thunder;
+        color: $white;
         text-decoration: none;
-        height: 100%;
-
-        @include breakpoint(sm) {
-            height: ($baseline * 6);
-            padding: 14px 0 10px $col;
-        }
-
-        @include breakpoint(md) {
-            display: inline-block;
-            padding: 5px $baseline*2 9px $baseline*2;
-            border-left: 1px solid $thunder;
-            font-size: 13px; // smaller font on medium for retina screens
-        }
-
-        @include breakpoint(lg) {
-            font-size: 14px;
-        }
-
-        //set focus styling - has to be on link to work (hover styling on li)
-        &:focus {
-            @include breakpoint(md) {
-                border-left: 1px solid $thunder;
-                background-color: $thunder;
-                color: $white;
-                text-decoration: none;
-            }
-        }
-
-        //show sub-menu on keyboard focus of link
-        &:focus + ul {
-            top: 100%;
-
-            @include breakpoint(md) {
-                background-color: $thunder;
-                text-decoration: none;
-                display: block;
-            }
-        }
-
-        &:focus.hide-children + ul {
-            left: -99999px // override class to hide menu even when expandable item has focus
-        }
-
+        display: block;
+      }
     }
 
-    //NAVIGATION CHILDREN
-
-    &__child-list {
-        list-style: none;
+    //set hover styling - done on link so it works on keyboard tab
+    &:hover > a,
+    &:focus > a,
+    &--focus > a {
+      @include breakpoint(md) {
+        border-left: 1px solid $thunder;
+        background-color: $thunder;
         color: $white;
-        margin: 0;
-
-        @include breakpoint(sm) {
-            //display: none; //done with js-nav-hidden class
-            background-color: $ship-grey;
-            padding: 0;
-        }
-
-        @include breakpoint(md) {
-            position: absolute;
-            padding: 0;
-            z-index: 10;
-            display: none;
-            border: 1px solid $thunder;
-        }
+        text-decoration: none;
+      }
     }
 
-    &__child-item {
-        display: block;
-        margin: 0;
-        padding: 0;
-
-        &--active {
-            background-color: $cod-gray;
+    &--active {
+      @include breakpoint(sm) {
+        & > a {
+          background-color: $active;
         }
-    }
+      }
 
-    &__child-link {
-        display: block;
+      @include breakpoint(md) {
+        background-color: $active;
+      }
+
+      & > a {
         color: $white;
+      }
+    }
+  }
 
-        @include breakpoint(sm) {
-            height: 48px;
-            padding: 14px 0 12px $col;
-        }
+  &__link {
+    color: $iron-light;
+    text-decoration: none;
+    height: 100%;
 
-        @include breakpoint(md) {
-            padding: 14px 0 10px $col;
-
-            &:hover,
-            &:focus {
-                outline: 0;
-                background-color: $iron;
-                text-decoration: none;
-                color: $thunder;
-            }
-        }
+    @include breakpoint(sm) {
+      height: ($baseline * 6);
+      padding: 14px 0 10px $col;
     }
 
-    &__language {
+    @include breakpoint(md) {
+      display: inline-block;
+      padding: 5px $baseline * 2 9px $baseline * 2;
+      border-left: 1px solid $thunder;
+      font-size: 13px; // smaller font on medium for retina screens
+    }
+
+    @include breakpoint(lg) {
+      font-size: 14px;
+    }
+
+    //set focus styling - has to be on link to work (hover styling on li)
+    &:focus {
+      @include breakpoint(md) {
+        border-left: 1px solid $thunder;
+        background-color: $thunder;
+        color: $white;
+        text-decoration: none;
+      }
+    }
+
+    //show sub-menu on keyboard focus of link
+    &:focus + ul {
+      top: 100%;
+
+      @include breakpoint(md) {
+        background-color: $thunder;
+        text-decoration: none;
         display: block;
-        color: $iron-light;
-        overflow: hidden;
-        margin: 0;
-        padding-left: 32px;
+      }
     }
+
+    &:focus.hide-children + ul {
+      left: -99999px; // override class to hide menu even when expandable item has focus
+    }
+  }
+
+  //NAVIGATION CHILDREN
+
+  &__child-list {
+    list-style: none;
+    color: $white;
+    margin: 0;
+
+    @include breakpoint(sm) {
+      background-color: $ship-grey;
+      padding: 0;
+    }
+
+    @include breakpoint(md) {
+      position: absolute;
+      padding: 0;
+      z-index: 10;
+      display: none;
+      border: 1px solid $thunder;
+    }
+  }
+
+  &__child-item {
+    display: block;
+    margin: 0;
+    padding: 0;
+
+    &--active {
+      background-color: $cod-gray;
+    }
+  }
+
+  &__child-link {
+    display: block;
+    color: $white;
+    text-decoration: none;
+
+    @include breakpoint(sm) {
+      height: 48px;
+      padding: 14px 0 12px $col;
+    }
+
+    @include breakpoint(md) {
+      padding: 14px 0 10px $col;
+
+      &:hover,
+      &:focus {
+        outline: 0;
+        background-color: $iron;
+        text-decoration: none;
+        color: $thunder;
+      }
+    }
+  }
+
+  &__language {
+    display: block;
+    color: $iron-light;
+    overflow: hidden;
+    margin: 0;
+    padding-left: 32px;
+  }
 }
 
 //JQUERY EXPANDABLE MOBILE MENU - temporary until we write our own JS in new library
 
 .js-nav-hidden {
-    @include breakpoint(sm) {
-        display: none;
-    }
+  @include breakpoint(sm) {
+    display: none;
+  }
 }
 
 .js-expandable-active {
-    @include breakpoint(sm) {
-        & > a {
-            background-color: $thunder;
-            //border-bottom: 1px solid $thunder;
-        }
-
-        & ul {
-            display: block !important;
-        }
+  @include breakpoint(sm) {
+    & > a {
+      background-color: $thunder;
     }
+
+    & ul {
+      display: block !important;
+    }
+  }
 }
 
 .nav__top-level-duplicate {
-    @extend .primary-nav__child-item;
+  @extend .primary-nav__child-item;
 
-    & > a {
-        @extend .primary-nav__child-link;
-    }
+  & > a {
+    @extend .primary-nav__child-link;
+  }
 
-    @include breakpoint(md) {
-        display: none;
-    }
+  @include breakpoint(md) {
+    display: none;
+  }
 }
 
 //Add plus symbol - class used for JS too
 .js-expandable {
-    @include breakpoint(sm) {
-        & > a > .expansion-indicator {
-            display: initial;
-            visibility: initial;
+  @include breakpoint(sm) {
+    & > a > .expansion-indicator {
+      display: initial;
+      visibility: initial;
 
-            &:before {
-                position: absolute;
-                color: $iron-light;
-                content: '+';
-                left: $col;
+      &:before {
+        position: absolute;
+        color: $iron-light;
+        content: "+";
+        left: $col;
 
-                @if $old-ie == true {
-                    content: '';
-
-                }
-            }
+        @if $old-ie == true {
+          content: "";
         }
-
-        &-active {
-            & > a  > .expansion-indicator {
-                &:before {
-                    content: '-';
-                    padding-left: 5px;
-                }
-            }
-        }
+      }
     }
+
+    &-active {
+      & > a > .expansion-indicator {
+        &:before {
+          content: "-";
+          padding-left: 5px;
+        }
+      }
+    }
+  }
 }
 
 //Menu and search controls - TODO rewrite with mobile
 .nav--controls {
-    list-style: none;
-    margin: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: stretch;
+
+  @include breakpoint(md) {
+    display: none;
+  }
+
+  &__item {
     padding: 0;
-    display: flex;
-    align-items: stretch;
+    margin: 0;
+    display: inline-block;
+    width: 50%;
+  }
 
-    @include breakpoint(md) {
-        display: none;
-    }
+  &__menu {
+    background-color: $ship-grey;
+    font-size: 17px;
+    float: left;
+    width: 100%;
+    padding: $baseline * 2 $col;
+    color: $iron-light;
+    border-right: 1px solid $thunder;
+  }
 
-    &__item {
-        padding: 0;
-        margin: 0;
-        display: inline-block;
-        width: 50%;
-    }
+  &__no-search {
+    width: 100%;
+  }
 
-    &__menu {
-        background-color: $ship-grey;
-        font-size: 17px;
-        float: left;
-        width: 100%;
-        //padding-left: $col;
-        padding: $baseline*2 $col;
-        color: $iron-light;
-        border-right: 1px solid $thunder;
-    }
-
-    &__no-search {
-      width:100%;
-    }
-
-    &__search {
-        background-color: $ship-grey;
-        font-size: 17px;
-        float: left;
-        width: 100%;
-        //padding-left: $col;
-        padding: $baseline*2 $col;
-        color: $iron-light;
-        // border-bottom: 1px solid $ship-grey;
-        // margin-bottom: -1px;
-    }
+  &__search {
+    background-color: $ship-grey;
+    font-size: 17px;
+    float: left;
+    width: 100%;
+    padding: $baseline * 2 $col;
+    color: $iron-light;
+  }
 }
 
 .menu-is-expanded {
-    & > a {
-        background-color: $abbey;
-    }
+  & > a {
+    background-color: $abbey;
+  }
 }
 
 .search-is-expanded {
-    & > a {
-        background-color: $abbey;
-    }
+  & > a {
+    background-color: $abbey;
+  }
 }
 
 .nav-main--hidden {
-    @include breakpoint(sm) {
-        display: none;
-    }
+  @include breakpoint(sm) {
+    display: none;
+  }
 }
 
 .nav-search--hidden {
-    @include breakpoint(sm) {
-        display: none;
-    }
+  @include breakpoint(sm) {
+    display: none;
+  }
 }
 
 // HEADER - LOGO, LANGUAGE SELECTION AND SECONDARY NAV LINKS
 
 // Header
 .header {
-    padding: 15px 0 9px 0;
-    position: relative; // So language toggle has relative parent
-    height: ($baseline * 9);
+  padding: 15px 0 9px 0;
+  position: relative; // So language toggle has relative parent
+  height: ($baseline * 9);
 
-    &--separator {
-        background-color: $ship-grey;
-        height: 2px;
-    }
+  &--separator {
+    background-color: $ship-grey;
+    height: 2px;
+  }
 }
 
 // Logo
 .logo {
-    display: block;
+  display: block;
 
-    @include breakpoint(sm) {
-        height: $baseline * 6;
-        padding: 2px 0 6px 0; //off-grid on mobile otherwise
-    }
+  @include breakpoint(sm) {
+    height: $baseline * 6;
+    padding: 2px 0 6px 0; //off-grid on mobile otherwise
+  }
 
-    @include breakpoint(md) {
-        height: 39px;
-        margin-top: 2px;
-    }
+  @include breakpoint(md) {
+    height: 39px;
+    margin-top: 2px;
+  }
 }
 
 // Secondary navigation list
 .secondary-nav {
+  @include breakpoint(md-max) {
+    margin: 0;
+    max-width: 55%;
+    float: right;
+  }
 
-    // Fix for old-ie hiding mobile--hide class
-    @if $old-ie == false {
-        @include breakpoint(sm) {
-            display: none;
-        }
+  // Fix for old-ie hiding mobile--hide class
+  @if $old-ie == false {
+    @include breakpoint(sm) {
+      display: none;
+    }
+  }
+
+  &__list {
+    float: right;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 24px;
+  }
+
+  &__item {
+    float: left;
+    margin: 0;
+    padding: 0;
+
+    &:last-child a {
+      padding-right: 0;
+      border-right: 0 solid;
+    }
+  }
+
+  &__link {
+    padding: 0 8px 0 8px;
+    border-right: 1px solid $iron-light;
+    text-decoration: none;
+
+    &--active {
+      @include breakpoint(sm) {
+        background-color: $active;
+      }
     }
 
-    &__list {
-        float: right;
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        font-size: 14px;
-        font-weight: 400;
-        line-height: 24px;
+    &:hover {
+      text-decoration: underline;
     }
-
-    &__item {
-        //display: inline-block;
-        float: left;
-        margin: 0;
-        padding: 0;
-
-        &:last-child a {
-            padding-right: 0;
-            border-right: 0 solid;
-        }
-
-    }
-
-    &__link {
-        padding: 0 8px 0 8px;
-        border-right: 1px solid $iron-light;
-        text-decoration: none;
-
-        &--active {
-            @include breakpoint(sm) {
-                background-color: $active;
-            }
-        }
-
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-
+  }
 }
 
 // 'Skip to main content' keyboard tabbable link
 .skiplink {
-    position: absolute;
-    left: -99999px;
+  position: absolute;
+  left: -99999px;
 
-    &:focus {
-        background: $ship-grey;
-        color: $white;
-        top: 0;
-        right: 0;
-        left: 0;
-        margin: 0 auto;
-        z-index: 10;
-        width: ($col * 10);
-        padding: 6px 0 10px 0;
-        font-size: 14px;
-        text-align: center;
-    }
+  &:focus {
+    background: $ship-grey;
+    color: $white;
+    top: 0;
+    right: 0;
+    left: 0;
+    margin: 0 auto;
+    z-index: 10;
+    width: ($col * 10);
+    padding: 6px 0 10px 0;
+    font-size: 14px;
+    text-align: center;
+  }
 }

--- a/src/scss/dp/overrides/components/_header.scss
+++ b/src/scss/dp/overrides/components/_header.scss
@@ -34,6 +34,7 @@
     padding: 0;
     cursor: pointer;
     display: inline-block;
+    flex-grow: 1;
 
     @include breakpoint(sm) {
       height: $baseline * 6;
@@ -42,7 +43,7 @@
     }
 
     @include breakpoint(md) {
-      &:nth-child(6) a {
+      &:nth-child(6) {
         border-right: 1px solid $thunder;
       }
     }
@@ -56,6 +57,15 @@
         color: $white;
         text-decoration: none;
         display: block;
+        width: 32.75%;
+      }
+
+      @include breakpoint(md-max) {
+        width: unset;
+      }
+
+      @include breakpoint(sm) {
+        width: 100%;
       }
     }
 
@@ -68,6 +78,11 @@
         background-color: $thunder;
         color: $white;
         text-decoration: none;
+      }
+    }
+    &:hover {
+      @include breakpoint(md) {
+        background-color: $thunder;
       }
     }
 
@@ -116,6 +131,13 @@
         background-color: $thunder;
         color: $white;
         text-decoration: none;
+      }
+    }
+
+    &:hover,
+    &:hover {
+      @include breakpoint(sm) {
+        color: $white;
       }
     }
 
@@ -195,6 +217,12 @@
     overflow: hidden;
     margin: 0;
     padding-left: 32px;
+
+    @include breakpoint(sm) {
+      & a.language__link {
+        color: $white;
+      }
+    }
   }
 }
 
@@ -287,6 +315,15 @@
     padding: $baseline * 2 $col;
     color: $iron-light;
     border-right: 1px solid $thunder;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      @include breakpoint(sm) {
+        color: $white;
+        text-decoration: none;
+      }
+    }
   }
 
   &__no-search {
@@ -300,6 +337,15 @@
     width: 100%;
     padding: $baseline * 2 $col;
     color: $iron-light;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      @include breakpoint(sm) {
+        color: $white;
+        text-decoration: none;
+      }
+    }
   }
 }
 
@@ -360,9 +406,10 @@
 .secondary-nav {
   @include breakpoint(md-max) {
     margin: 0;
-    max-width: 55%;
-    float: right;
   }
+
+  max-width: 55%;
+  float: right;
 
   // Fix for old-ie hiding mobile--hide class
   @if $old-ie == false {

--- a/src/scss/dp/overrides/components/_header.scss
+++ b/src/scss/dp/overrides/components/_header.scss
@@ -134,10 +134,10 @@
       }
     }
 
-    &:hover,
     &:hover {
       @include breakpoint(sm) {
         color: $white;
+        text-decoration: underline;
       }
     }
 
@@ -196,6 +196,12 @@
     @include breakpoint(sm) {
       height: 48px;
       padding: 14px 0 12px $col;
+
+      &:hover,
+      &:focus {
+        color: $white;
+        text-decoration: underline;
+      }
     }
 
     @include breakpoint(md) {

--- a/src/scss/dp/overrides/components/_header.scss
+++ b/src/scss/dp/overrides/components/_header.scss
@@ -1,0 +1,432 @@
+// _header.scss
+
+// PRIMARY NAVIGATION
+
+.primary-nav {
+
+    background-color: $abbey;
+    position: relative;
+
+    @include breakpoint(md) {
+        border-top: 1px solid $thunder;
+        border-bottom: 1px solid $thunder;
+    }
+
+    &__list {
+        list-style: none;
+        margin: 0 auto;
+        font-size: 0;
+        display: flex;
+        align-items: stretch;
+
+        @include breakpoint(sm) {
+            padding: 0 0 $baseline 0;
+            display: block;
+        }
+    }
+
+    &__item {
+        margin: 0;
+        padding: 0;
+        cursor: pointer;
+        display: inline-block;
+
+        @include breakpoint(sm) {
+            height: $baseline * 6;
+            display: block;
+            padding-left: 16px;
+        }
+
+        @include breakpoint(md) {
+            &:nth-child(6) a {
+                border-right: 1px solid $thunder;
+            }
+        }
+
+        //children show on hover
+        &:hover > ul,
+        &--focus > ul {
+            top: 100%;
+            @include breakpoint(md) {
+                background-color: $thunder;
+                color: $white;
+                text-decoration: none;
+                display: block;
+            }
+        }
+
+        //set hover styling - done on link so it works on keyboard tab
+        &:hover > a,
+        &:focus > a,
+        &--focus > a {
+            @include breakpoint(md) {
+                border-left: 1px solid $thunder;
+                background-color: $thunder;
+                color: $white;
+                text-decoration: none;
+            }
+        }
+
+        &--active {
+            @include breakpoint(sm) {
+                & > a {
+                    background-color: $active;
+                }
+            }
+
+            @include breakpoint(md) {
+                background-color: $active;
+            }
+
+            & > a {
+                color: $white;
+            }
+        }
+
+    }
+
+    &__link {
+        color: $iron-light;
+        text-decoration: none;
+        height: 100%;
+
+        @include breakpoint(sm) {
+            height: ($baseline * 6);
+            padding: 14px 0 10px $col;
+        }
+
+        @include breakpoint(md) {
+            display: inline-block;
+            padding: 5px $baseline*2 9px $baseline*2;
+            border-left: 1px solid $thunder;
+            font-size: 13px; // smaller font on medium for retina screens
+        }
+
+        @include breakpoint(lg) {
+            font-size: 14px;
+        }
+
+        //set focus styling - has to be on link to work (hover styling on li)
+        &:focus {
+            @include breakpoint(md) {
+                border-left: 1px solid $thunder;
+                background-color: $thunder;
+                color: $white;
+                text-decoration: none;
+            }
+        }
+
+        //show sub-menu on keyboard focus of link
+        &:focus + ul {
+            top: 100%;
+
+            @include breakpoint(md) {
+                background-color: $thunder;
+                text-decoration: none;
+                display: block;
+            }
+        }
+
+        &:focus.hide-children + ul {
+            left: -99999px // override class to hide menu even when expandable item has focus
+        }
+
+    }
+
+    //NAVIGATION CHILDREN
+
+    &__child-list {
+        list-style: none;
+        color: $white;
+        margin: 0;
+
+        @include breakpoint(sm) {
+            //display: none; //done with js-nav-hidden class
+            background-color: $ship-grey;
+            padding: 0;
+        }
+
+        @include breakpoint(md) {
+            position: absolute;
+            padding: 0;
+            z-index: 10;
+            display: none;
+            border: 1px solid $thunder;
+        }
+    }
+
+    &__child-item {
+        display: block;
+        margin: 0;
+        padding: 0;
+
+        &--active {
+            background-color: $cod-gray;
+        }
+    }
+
+    &__child-link {
+        display: block;
+        color: $white;
+
+        @include breakpoint(sm) {
+            height: 48px;
+            padding: 14px 0 12px $col;
+        }
+
+        @include breakpoint(md) {
+            padding: 14px 0 10px $col;
+
+            &:hover,
+            &:focus {
+                outline: 0;
+                background-color: $iron;
+                text-decoration: none;
+                color: $thunder;
+            }
+        }
+    }
+
+    &__language {
+        display: block;
+        color: $iron-light;
+        overflow: hidden;
+        margin: 0;
+        padding-left: 32px;
+    }
+}
+
+//JQUERY EXPANDABLE MOBILE MENU - temporary until we write our own JS in new library
+
+.js-nav-hidden {
+    @include breakpoint(sm) {
+        display: none;
+    }
+}
+
+.js-expandable-active {
+    @include breakpoint(sm) {
+        & > a {
+            background-color: $thunder;
+            //border-bottom: 1px solid $thunder;
+        }
+
+        & ul {
+            display: block !important;
+        }
+    }
+}
+
+.nav__top-level-duplicate {
+    @extend .primary-nav__child-item;
+
+    & > a {
+        @extend .primary-nav__child-link;
+    }
+
+    @include breakpoint(md) {
+        display: none;
+    }
+}
+
+//Add plus symbol - class used for JS too
+.js-expandable {
+    @include breakpoint(sm) {
+        & > a > .expansion-indicator {
+            display: initial;
+            visibility: initial;
+
+            &:before {
+                position: absolute;
+                color: $iron-light;
+                content: '+';
+                left: $col;
+
+                @if $old-ie == true {
+                    content: '';
+
+                }
+            }
+        }
+
+        &-active {
+            & > a  > .expansion-indicator {
+                &:before {
+                    content: '-';
+                    padding-left: 5px;
+                }
+            }
+        }
+    }
+}
+
+//Menu and search controls - TODO rewrite with mobile
+.nav--controls {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: stretch;
+
+    @include breakpoint(md) {
+        display: none;
+    }
+
+    &__item {
+        padding: 0;
+        margin: 0;
+        display: inline-block;
+        width: 50%;
+    }
+
+    &__menu {
+        background-color: $ship-grey;
+        font-size: 17px;
+        float: left;
+        width: 100%;
+        //padding-left: $col;
+        padding: $baseline*2 $col;
+        color: $iron-light;
+        border-right: 1px solid $thunder;
+    }
+
+    &__no-search {
+      width:100%;
+    }
+
+    &__search {
+        background-color: $ship-grey;
+        font-size: 17px;
+        float: left;
+        width: 100%;
+        //padding-left: $col;
+        padding: $baseline*2 $col;
+        color: $iron-light;
+        // border-bottom: 1px solid $ship-grey;
+        // margin-bottom: -1px;
+    }
+}
+
+.menu-is-expanded {
+    & > a {
+        background-color: $abbey;
+    }
+}
+
+.search-is-expanded {
+    & > a {
+        background-color: $abbey;
+    }
+}
+
+.nav-main--hidden {
+    @include breakpoint(sm) {
+        display: none;
+    }
+}
+
+.nav-search--hidden {
+    @include breakpoint(sm) {
+        display: none;
+    }
+}
+
+// HEADER - LOGO, LANGUAGE SELECTION AND SECONDARY NAV LINKS
+
+// Header
+.header {
+    padding: 15px 0 9px 0;
+    position: relative; // So language toggle has relative parent
+    height: ($baseline * 9);
+
+    &--separator {
+        background-color: $ship-grey;
+        height: 2px;
+    }
+}
+
+// Logo
+.logo {
+    display: block;
+
+    @include breakpoint(sm) {
+        height: $baseline * 6;
+        padding: 2px 0 6px 0; //off-grid on mobile otherwise
+    }
+
+    @include breakpoint(md) {
+        height: 39px;
+        margin-top: 2px;
+    }
+}
+
+// Secondary navigation list
+.secondary-nav {
+
+    // Fix for old-ie hiding mobile--hide class
+    @if $old-ie == false {
+        @include breakpoint(sm) {
+            display: none;
+        }
+    }
+
+    &__list {
+        float: right;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 24px;
+    }
+
+    &__item {
+        //display: inline-block;
+        float: left;
+        margin: 0;
+        padding: 0;
+
+        &:last-child a {
+            padding-right: 0;
+            border-right: 0 solid;
+        }
+
+    }
+
+    &__link {
+        padding: 0 8px 0 8px;
+        border-right: 1px solid $iron-light;
+        text-decoration: none;
+
+        &--active {
+            @include breakpoint(sm) {
+                background-color: $active;
+            }
+        }
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+}
+
+// 'Skip to main content' keyboard tabbable link
+.skiplink {
+    position: absolute;
+    left: -99999px;
+
+    &:focus {
+        background: $ship-grey;
+        color: $white;
+        top: 0;
+        right: 0;
+        left: 0;
+        margin: 0 auto;
+        z-index: 10;
+        width: ($col * 10);
+        padding: 6px 0 10px 0;
+        font-size: 14px;
+        text-align: center;
+    }
+}

--- a/src/scss/dp/overrides/components/_improve-this-page.scss
+++ b/src/scss/dp/overrides/components/_improve-this-page.scss
@@ -1,0 +1,114 @@
+.improve-this-page{
+
+    &__prompt{
+        background-color: #3B7A9E;
+        color: #fff;
+        padding: 10px 15px 10px;
+
+        a{
+            color: #fff;
+            display: inline-block;
+        }
+    }
+
+    &__form{
+        margin-top: 30px;
+        padding: 15px 0;
+        border-top: 10px solid #3B7A9E;
+
+        .form-control{
+            width: 100%;
+            opacity: 1;
+            -webkit-appearance: none;
+            border-radius: 0;
+            background-image: none;
+            box-sizing: border-box;
+            font-weight: 400;
+            text-transform: none;
+            line-height: 1.25;
+            padding: 5px 4px 4px;
+            border: 2px solid #0b0c0c;
+            margin-bottom: 40px;
+
+            @media (min-width: 641px) {
+                width: 70%;
+                font-size: 16px;
+                line-height: 1.31579;
+            }
+
+            &__error {
+                outline: 3px solid $poppy;
+                outline-offset: -2px;
+                border: none;
+            }
+        }
+
+        .form-control:focus{
+            outline: 3px solid $carrot;
+            outline-offset: -2px;
+            border: none;
+        }
+
+        textarea{
+            display: block;
+        }
+
+        .form-label{
+
+            &-bold{
+                font-weight: 700;
+                line-height: 1.25;
+                text-transform: none;
+                display: block;
+                color: #0b0c0c;
+                padding-bottom: 2px;
+                margin-bottom: 4px;
+
+                .form-hint{
+                    text-transform: none;
+                    display: block;
+                    color: #6f777b;
+                    font-weight: normal;
+                }
+
+                .form-error{
+                    text-transform: none;
+                    display: block;
+                    color: $poppy;
+                    font-weight: 700;
+                    font-size: 16px;
+                }
+            }
+            
+            font-weight: 400;
+            text-transform: none;
+            display: block;
+            color: #0b0c0c;
+            padding-bottom: 2px;
+            margin-bottom: 4px;
+
+            @media (min-width: 641px) {
+                line-height: 1.31579;
+            }
+        }
+    }
+
+    &__is-useful-question{
+        font-weight: 700;
+        text-transform: none;
+        display: inline;
+    }
+
+    &__page-is-useful-button{
+        margin-right: 0.2em;
+    }
+
+    &__anything-wrong{
+        float: right;
+
+        @include breakpoint(sm) {
+           float: none;
+           margin: $col 0 $baseline 0;
+        }
+    }
+}

--- a/src/scss/dp/overrides/components/_improve-this-page.scss
+++ b/src/scss/dp/overrides/components/_improve-this-page.scss
@@ -1,114 +1,119 @@
-.improve-this-page{
+.improve-this-page {
+  &__prompt {
+    background-color: $astral;
+    color: $white;
+    padding: 10px 15px 10px;
 
-    &__prompt{
-        background-color: #3B7A9E;
-        color: #fff;
-        padding: 10px 15px 10px;
+    a {
+      color: $white;
+      display: inline-block;
+    }
+  }
 
-        a{
-            color: #fff;
-            display: inline-block;
-        }
+  &__form {
+    margin-top: 30px;
+    padding: 15px 0;
+    border-top: 10px solid $astral;
+
+    .form-control {
+      width: 100%;
+      opacity: 1;
+      -webkit-appearance: none;
+      border-radius: 0;
+      background-image: none;
+      box-sizing: border-box;
+      font-weight: 400;
+      text-transform: none;
+      line-height: 1.25;
+      padding: 5px 4px 4px;
+      border: 2px solid #0b0c0c;
+      margin-bottom: 40px;
+
+      @media (min-width: 641px) {
+        width: 70%;
+        font-size: 16px;
+        line-height: 1.31579;
+      }
+
+      &__error {
+        outline: 3px solid $poppy;
+        outline-offset: -2px;
+        border: none;
+      }
     }
 
-    &__form{
-        margin-top: 30px;
-        padding: 15px 0;
-        border-top: 10px solid #3B7A9E;
-
-        .form-control{
-            width: 100%;
-            opacity: 1;
-            -webkit-appearance: none;
-            border-radius: 0;
-            background-image: none;
-            box-sizing: border-box;
-            font-weight: 400;
-            text-transform: none;
-            line-height: 1.25;
-            padding: 5px 4px 4px;
-            border: 2px solid #0b0c0c;
-            margin-bottom: 40px;
-
-            @media (min-width: 641px) {
-                width: 70%;
-                font-size: 16px;
-                line-height: 1.31579;
-            }
-
-            &__error {
-                outline: 3px solid $poppy;
-                outline-offset: -2px;
-                border: none;
-            }
-        }
-
-        .form-control:focus{
-            outline: 3px solid $carrot;
-            outline-offset: -2px;
-            border: none;
-        }
-
-        textarea{
-            display: block;
-        }
-
-        .form-label{
-
-            &-bold{
-                font-weight: 700;
-                line-height: 1.25;
-                text-transform: none;
-                display: block;
-                color: #0b0c0c;
-                padding-bottom: 2px;
-                margin-bottom: 4px;
-
-                .form-hint{
-                    text-transform: none;
-                    display: block;
-                    color: #6f777b;
-                    font-weight: normal;
-                }
-
-                .form-error{
-                    text-transform: none;
-                    display: block;
-                    color: $poppy;
-                    font-weight: 700;
-                    font-size: 16px;
-                }
-            }
-            
-            font-weight: 400;
-            text-transform: none;
-            display: block;
-            color: #0b0c0c;
-            padding-bottom: 2px;
-            margin-bottom: 4px;
-
-            @media (min-width: 641px) {
-                line-height: 1.31579;
-            }
-        }
+    .form-control:focus {
+      outline: 3px solid $carrot;
+      outline-offset: -2px;
+      border: none;
     }
 
-    &__is-useful-question{
+    textarea {
+      display: block;
+    }
+
+    .form-label {
+      &-bold {
         font-weight: 700;
+        line-height: 1.25;
         text-transform: none;
-        display: inline;
-    }
+        display: block;
+        color: #0b0c0c;
+        padding-bottom: 2px;
+        margin-bottom: 4px;
 
-    &__page-is-useful-button{
-        margin-right: 0.2em;
-    }
-
-    &__anything-wrong{
-        float: right;
-
-        @include breakpoint(sm) {
-           float: none;
-           margin: $col 0 $baseline 0;
+        .form-hint {
+          text-transform: none;
+          display: block;
+          color: #6f777b;
+          font-weight: normal;
         }
+
+        .form-error {
+          text-transform: none;
+          display: block;
+          color: $poppy;
+          font-weight: 700;
+          font-size: 16px;
+        }
+      }
+
+      font-weight: 400;
+      text-transform: none;
+      display: block;
+      color: #0b0c0c;
+      padding-bottom: 2px;
+      margin-bottom: 4px;
+
+      @media (min-width: 641px) {
+        line-height: 1.31579;
+      }
     }
+  }
+
+  &__is-useful-question {
+    font-weight: 700;
+    text-transform: none;
+    display: inline;
+  }
+
+  &__page-is-useful-button {
+    margin-right: 0.2em;
+  }
+
+  &__anything-wrong {
+    float: right;
+
+    @include breakpoint(sm) {
+      float: none;
+      margin: $col 0 $baseline 0;
+    }
+  }
+}
+
+#feedback-form-close {
+  &:hover {
+    color: $white;
+    text-decoration: underline;
+  }
 }

--- a/src/scss/dp/overrides/components/_language-toggle.scss
+++ b/src/scss/dp/overrides/components/_language-toggle.scss
@@ -1,0 +1,51 @@
+// Language selection
+.language {
+    font-size: 12px;
+
+    @include breakpoint(md) {
+        float: right;
+    }
+
+    &__title {
+        display: inline;
+    }
+
+    &__item {
+        margin: 0 0 0 4px;
+        display: inline;
+    }
+
+    // Styles for js enhanced <select> form
+    &--js {
+        display: none; // Hide until enhanced and shown on page
+        min-width: ($col * 10);
+
+        &__label {
+            font-size: 12px;
+        }
+
+        &__select {
+            padding-bottom: 2px; // Fixes text being 1 pixel below label text
+            float: right;
+            border: 0 !important;
+            font-size: 12px;
+            height: 24px;
+            color: $matisse;
+            -webkit-appearance: none;  /*Removes default chrome and safari style*/
+            -moz-appearance: none; /* Removes Default Firefox style*/
+            text-indent: 0.01px; /* Removes default arrow from firefox*/
+            text-overflow: "";  /*Removes default arrow from firefox*/
+            
+            // IE10+ fixes
+            &::-ms-expand {
+                display: none;
+            }
+            &:focus::-ms-value {
+                color: $matisse;
+            }
+            &:hover {
+                cursor: pointer;
+            }
+        }
+    }
+}

--- a/src/scss/dp/overrides/components/_language-toggle.scss
+++ b/src/scss/dp/overrides/components/_language-toggle.scss
@@ -2,9 +2,10 @@
   &--js__container {
     @include breakpoint(md-max) {
       margin: 0;
-      max-width: 55%;
-      float: right;
     }
+
+    max-width: 55%;
+    float: right;
 
     // Language selection
     & .language {

--- a/src/scss/dp/overrides/components/_language-toggle.scss
+++ b/src/scss/dp/overrides/components/_language-toggle.scss
@@ -1,51 +1,62 @@
-// Language selection
 .language {
-    font-size: 12px;
+  &--js__container {
+    @include breakpoint(md-max) {
+      margin: 0;
+      max-width: 55%;
+      float: right;
+    }
 
-    @include breakpoint(md) {
+    // Language selection
+    & .language {
+      font-size: 12px;
+      margin-bottom: 0.25rem;
+
+      @include breakpoint(md) {
         float: right;
-    }
+      }
 
-    &__title {
+      &__title {
         display: inline;
-    }
+      }
 
-    &__item {
+      &__item {
         margin: 0 0 0 4px;
         display: inline;
-    }
+      }
 
-    // Styles for js enhanced <select> form
-    &--js {
+      // Styles for js enhanced <select> form
+      &--js {
         display: none; // Hide until enhanced and shown on page
         min-width: ($col * 10);
 
         &__label {
-            font-size: 12px;
+          font-size: 12px;
         }
 
         &__select {
-            padding-bottom: 2px; // Fixes text being 1 pixel below label text
-            float: right;
-            border: 0 !important;
-            font-size: 12px;
-            height: 24px;
+          padding-bottom: 2px; // Fixes text being 1 pixel below label text
+          float: right;
+          border: 0 !important;
+          font-size: 12px;
+          height: 24px;
+          color: $matisse;
+          -webkit-appearance: none; /*Removes default chrome and safari style*/
+          -moz-appearance: none; /* Removes Default Firefox style*/
+          text-indent: 0.01px; /* Removes default arrow from firefox*/
+          text-overflow: ""; /*Removes default arrow from firefox*/
+
+          // IE10+ fixes
+          &::-ms-expand {
+            display: none;
+          }
+          &:focus::-ms-value {
             color: $matisse;
-            -webkit-appearance: none;  /*Removes default chrome and safari style*/
-            -moz-appearance: none; /* Removes Default Firefox style*/
-            text-indent: 0.01px; /* Removes default arrow from firefox*/
-            text-overflow: "";  /*Removes default arrow from firefox*/
-            
-            // IE10+ fixes
-            &::-ms-expand {
-                display: none;
-            }
-            &:focus::-ms-value {
-                color: $matisse;
-            }
-            &:hover {
-                cursor: pointer;
-            }
+          }
+          &:hover {
+            cursor: pointer;
+          }
         }
+      }
     }
+  }
 }

--- a/src/scss/dp/overrides/components/_nav.scss
+++ b/src/scss/dp/overrides/components/_nav.scss
@@ -1,0 +1,72 @@
+// nav.scss
+
+.nav-tile-holder {
+
+	&__heading {
+		margin-bottom: $baseline * 3;
+	}
+
+	&__list {
+		padding: 0;
+		list-style: none;
+	}
+
+	&__item {
+		padding: 6px 0 10px 0;
+	}
+}
+
+.nav {
+	&-primary {
+		//move primary nav items here...
+	}
+
+	&-secondary {
+		margin-bottom: ($baseline * 2);
+		padding-top: $baseline;
+
+		&__title {
+			margin: 0 0 0 0;
+			font-size: 21px;
+			font-weight: 400;
+			line-height: 24px;
+		}
+
+		&__list {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+		}
+
+		&__item {
+			display: inline-block;
+			margin: 0;
+			padding: 11px 0 5px 0;
+			line-height: 16px;
+
+			a {
+				text-decoration: underline;
+			}
+
+			&:after {
+				content: '|';
+				padding: 0 0 0 4px;
+				color: $aluminium;
+			}
+
+			&:last-child:after {
+				content: '';
+				padding: 0 0 0 0;
+			}
+
+		}
+
+		&--census {
+			color: $iron-light;
+			a {
+				color: $iron-light;
+			}
+		}
+	}
+
+}

--- a/src/scss/dp/overrides/components/_nav.scss
+++ b/src/scss/dp/overrides/components/_nav.scss
@@ -17,10 +17,6 @@
 }
 
 .nav {
-	&-primary {
-		//move primary nav items here...
-	}
-
 	&-secondary {
 		margin-bottom: ($baseline * 2);
 		padding-top: $baseline;

--- a/src/scss/dp/overrides/components/_search-bar.scss
+++ b/src/scss/dp/overrides/components/_search-bar.scss
@@ -1,0 +1,164 @@
+.search {
+  @include breakpoint(sm) {
+    background-color: $abbey;
+  }
+
+  @include breakpoint(md) {
+    background-color: $ship-grey;
+    font-size: 17px;
+    height: 80px;
+  }
+
+  &--results-page {
+    height: ($baseline * 24);
+
+    h1 {
+      color: $iron-light;
+      margin: ($baseline * 2) 0 $baseline 0;
+    }
+
+    @if $old-ie == false {
+      @include breakpoint(sm) {
+        height: auto;
+        h1 {
+          font-size: 21px;
+          line-height: ($baseline * 4);
+        }
+      }
+    }
+  }
+
+  &__form {
+    font-family: $base-font-family;
+    font-weight: inherit;
+    line-height: $base-line-height;
+    color: $iron-light;
+    padding: ($baseline * 2) 0 ($baseline * 2) ($baseline * 2);
+    overflow: initial;
+
+    @if $old-ie == false {
+      @include breakpoint(sm) {
+        padding: ($baseline * 3) 0;
+        overflow: hidden;
+      }
+    }
+
+    @include breakpoint(md-max) {
+      display: flex;
+    }
+  }
+
+  &__label {
+    font-family: $base-font-family;
+    font-weight: inherit;
+    line-height: $base-line-height;
+    font-size: 17px;
+    color: $iron-light;
+    padding: 12px $col 12px 0;
+    background-color: transparent;
+    position: relative;
+
+    @if $old-ie == false {
+      @include breakpoint(sm) {
+        display: none;
+      }
+    }
+  }
+
+  &__input {
+    font-family: $base-font-family;
+    font-weight: inherit;
+    line-height: $base-line-height;
+    font-size: 17px;
+    color: $thunder;
+    border: none;
+    padding: 4px;
+    height: ($baseline * 6);
+    background: white;
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+
+    &:focus {
+      outline: 2px solid $carrot;
+      outline-offset: -2px;
+      z-index: 1;
+      position: relative;
+    }
+
+    @if $old-ie == false {
+      @include breakpoint(sm) {
+        width: 80%;
+        font-size: 14px;
+        padding: 12px $col/2 8px $col/2;
+      }
+    }
+
+    &--results-page {
+      height: ($baseline * 5);
+    }
+
+    &--body {
+      background: none;
+      outline: 2px solid $thunder;
+      outline-offset: 0;
+      z-index: 1;
+      position: relative;
+      float: left;
+    }
+  }
+
+  &__button {
+    font-family: $base-font-family;
+    font-weight: inherit;
+    line-height: $base-line-height;
+    font-size: 17px;
+    color: $white;
+    border: none;
+    padding: 0;
+    background-color: $primary;
+    height: ($baseline * 6);
+    position: relative;
+
+    &:hover,
+    &:focus {
+      background-color: darken($primary, 8%);
+    }
+
+    &:focus {
+      outline: 3px solid $carrot;
+    }
+
+    & > * {
+      display: flex;
+      justify-content: center;
+    }
+
+    @if $old-ie == false {
+      @include breakpoint(sm) {
+        width: 20%;
+        font-size: 14px;
+        padding-left: $col/2;
+        padding-right: $col/2;
+      }
+    }
+
+    &--results-page {
+      height: ($baseline * 5);
+      padding-top: ($baseline / 2);
+    }
+
+    &--body {
+      height: 52px;
+      width: 52px;
+      margin-top: -2px;
+      float: left;
+    }
+  }
+}
+
+[type="search"] {
+  &::-webkit-search-cancel-button,
+  ::-webkit-search-decoration {
+    -webkit-appearance: auto;
+  }
+}

--- a/src/scss/dp/overrides/components/_search-bar.scss
+++ b/src/scss/dp/overrides/components/_search-bar.scss
@@ -33,8 +33,9 @@
     font-weight: inherit;
     line-height: $base-line-height;
     color: $iron-light;
-    padding: ($baseline * 2) 0 ($baseline * 2) ($baseline * 2);
+    padding: ($baseline * 2) 0;
     overflow: initial;
+    display: flex;
 
     @if $old-ie == false {
       @include breakpoint(sm) {
@@ -57,6 +58,7 @@
     padding: 12px $col 12px 0;
     background-color: transparent;
     position: relative;
+    flex-grow: 1;
 
     @if $old-ie == false {
       @include breakpoint(sm) {
@@ -77,6 +79,7 @@
     background: white;
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
+    flex-grow: 1;
 
     &:focus {
       outline: 2px solid $carrot;


### PR DESCRIPTION
### What

- Adding styling and JS required for the header and footer
- Changed local port number to avoid conflict with `dp-compose/cantabular-import` minio service

### How to review

To run the changes locally you'll need to:
- Pull and run this branch
- Use a service that has been ported to use the `dp-renderer`; I recommend using a cantabular dataset landing page - there are [full instructions](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) on how to setup your mac to view these pages
   - If using the above ⬆️, you'll need to use the `replace` statement in `dp-frontend-dataset-controller` := follow these [instructions](https://github.com/ONSdigital/dp-renderer#referencing-a-local-instance-of-dp-renderer-in-a-docker-container)
- Update [dp-renderer/assets/templates/main.tmpl](https://github.com/ONSdigital/dp-renderer/blob/main/assets/templates/main.tmpl) to point to your local instance of the `dp-design-system`; I would recommend removing references to `Sixteens` in the template to have confidence that the changes are not dependent upon Sixteens

`main.tmpl` would look like something like this: 
```html
    {{ if .FeatureFlags.ONSDesignSystemVersion }}
      <link rel="stylesheet" href="http://localhost:9002/dist/assets/css/main.css">
    {{ end }}
...
    {{ if .FeatureFlags.ONSDesignSystemVersion }}
        </div>
      </div>
      <script src="http://localhost:9002/dist/assets/js/main.js"></script>
    {{end}}

```

- Once you have a page running, visually it should appear as the main site and the JS interactions should work as they currently do
- N.B. `dp-design-system` uses vanilla JS (no jQuery) unlike Sixteens; there appears to be a bug with `es5` bundle so testing in IE11 will result in errors. This bug is being actively worked on.

### Who can review

Frontend dev
