### PR TITLE
Fix/es5 bundling

### DIFF
--- a/babel.conf.nomodule.js
+++ b/babel.conf.nomodule.js
@@ -1,22 +1,22 @@
 module.exports = {
   babelrc: false,
   plugins: [
-    '@babel/plugin-syntax-dynamic-import',
-    '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-transform-runtime',
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-runtime",
   ],
   global: true,
-  ignore: [/node_modules\).*/],
-  sourceType: 'module',
+  ignore: [/node_modules\/(?!(chai-as-promised|fetch-mock)\/).*/],
+  sourceType: "module",
   presets: [
     [
-      '@babel/preset-env',
+      "@babel/preset-env",
       {
-        modules: 'commonjs',
+        modules: "commonjs",
         targets: {
-          browsers: ['ie 11'],
+          browsers: ["ie 11"],
         },
       },
     ],
   ],
-}
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,91 +1,92 @@
-const browserify = require('browserify')
-const gulp = require('gulp')
-const gulpIf = require('gulp-if')
-const buffer = require('vinyl-buffer')
-const source = require('vinyl-source-stream')
-const gulpTerser = require('gulp-terser')
-const sass = require('node-sass')
-const gulpSass = require('gulp-sass')
-const nodeSassGlobImporter = require('node-sass-glob-importer')
+const browserify = require("browserify");
+const gulp = require("gulp");
+const gulpIf = require("gulp-if");
+const buffer = require("vinyl-buffer");
+const source = require("vinyl-source-stream");
+const gulpTerser = require("gulp-terser");
+const sass = require("node-sass");
+const gulpSass = require("gulp-sass");
+const nodeSassGlobImporter = require("node-sass-glob-importer");
 
-const babelEsmConfig = require('./babel.conf.esm.js')
-const babelNomoduleConfig = require('./babel.conf.nomodule')
+const babelEsmConfig = require("./babel.conf.esm");
+const babelNomoduleConfig = require("./babel.conf.nomodule");
 
-const isProduction = process.env.NODE_ENV === 'production'
-const isDevelopment = !isProduction
+const isProduction = process.env.NODE_ENV === "production";
+const isDevelopment = !isProduction;
 
-const DESIGN_SYSTEM_MODULE_PATH = './node_modules/@ons/design-system'
-const OUTPUT_DIRECTORY = './dist/assets'
+const DESIGN_SYSTEM_MODULE_PATH = "./node_modules/@ons/design-system";
+const OUTPUT_DIRECTORY = "./dist/assets";
 
+// Two import files required as the design system's 'main.js' is compiled and produces numerous errors during re-bundling
 const scripts = [
   {
-    entryPoint: './src/js/main.js',
-    outputFile: 'main.js',
+    entryPoint: ["./src/js/import-ds.js", "./src/js/main.js"],
+    outputFile: "main.js",
     config: babelEsmConfig,
   },
   {
-    entryPoint: ['./src/js/polyfills.js', './src/js/main.js'],
-    outputFile: 'main.es5.js',
+    entryPoint: ["./src/js/import-ds.es5.js", "./src/js/polyfills.js", "./src/js/main.js"],
+    outputFile: "main.es5.js",
     config: babelNomoduleConfig,
   },
-]
+];
 
 function createBuildScriptTask({ entryPoint, outputFile, config }) {
-  const taskName = `build-script:${outputFile}`
+  const taskName = `build-script:${outputFile}`;
 
   const terserOptions = {
     compress: {
       drop_console: true,
     },
-  }
+  };
 
   gulp.task(taskName, () => {
     return browserify(entryPoint, { debug: isDevelopment })
-      .transform('babelify', { ...config })
+      .transform("babelify", { ...config })
       .bundle()
       .pipe(source(outputFile))
       .pipe(buffer())
       .pipe(gulpIf(isProduction, gulpTerser(terserOptions)))
-      .pipe(gulp.dest(`${OUTPUT_DIRECTORY}/js`))
-  })
-  return taskName
+      .pipe(gulp.dest(`${OUTPUT_DIRECTORY}/js`));
+  });
+  return taskName;
 }
 
-gulp.task('copy-static-assets-from-design-system', () => {
+gulp.task("copy-static-assets-from-design-system", () => {
   gulp
     .src(`${DESIGN_SYSTEM_MODULE_PATH}/fonts/**`)
-    .pipe(gulp.dest(`${OUTPUT_DIRECTORY}/fonts`))
+    .pipe(gulp.dest(`${OUTPUT_DIRECTORY}/fonts`));
   return gulp
     .src(`${DESIGN_SYSTEM_MODULE_PATH}/favicons/**`)
-    .pipe(gulp.dest(`${OUTPUT_DIRECTORY}/favicons`))
-})
+    .pipe(gulp.dest(`${OUTPUT_DIRECTORY}/favicons`));
+});
 
-gulp.task('build-styles', () => {
-  const sassCompiler = gulpSass(sass)
+gulp.task("build-styles", () => {
+  const sassCompiler = gulpSass(sass);
   const sassOptions = {
     importer: nodeSassGlobImporter(),
-    outputStyle: isProduction ? 'compressed' : '',
-  }
-  
+    outputStyle: isProduction ? "compressed" : "",
+  };
+
   return gulp
-    .src('./src/scss/*.scss')
-    .pipe(sassCompiler(sassOptions).on('error', sassCompiler.logError))
-    .pipe(gulp.dest('./dist/assets/css'))
-})
+    .src("./src/scss/*.scss")
+    .pipe(sassCompiler(sassOptions).on("error", sassCompiler.logError))
+    .pipe(gulp.dest("./dist/assets/css"));
+});
 
-gulp.task('build-script', gulp.series(...scripts.map(createBuildScriptTask)))
+gulp.task("build-script", gulp.series(...scripts.map(createBuildScriptTask)));
 
-gulp.task('watch-and-build', async () => {
-  gulp.watch('./src/js/**', gulp.series('build-script'))
-  gulp.watch('./src/scss/**/*.scss', gulp.series('build-styles'))
-})
+gulp.task("watch-and-build", async () => {
+  gulp.watch("./src/js/**", gulp.series("build-script"));
+  gulp.watch("./src/scss/**/*.scss", gulp.series("build-styles"));
+});
 
 gulp.task(
-  'build',
+  "build",
   gulp.series(
-    gulp.parallel('build-script', 'build-styles'),
-    'copy-static-assets-from-design-system'
+    gulp.parallel("build-script", "build-styles"),
+    "copy-static-assets-from-design-system"
   )
-)
+);
 
-gulp.task('watch', gulp.series('build', 'watch-and-build'))
+gulp.task("watch", gulp.series("build", "watch-and-build"));

--- a/src/js/import-ds.es5.js
+++ b/src/js/import-ds.es5.js
@@ -1,0 +1,1 @@
+import "@ons/design-system/scripts/main.es5";

--- a/src/js/import-ds.js
+++ b/src/js/import-ds.js
@@ -1,0 +1,1 @@
+import "@ons/design-system/scripts/main";

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,3 @@
-import "@ons/design-system/scripts/main";
-
 // DP-specific JS
 import "./dp/cookies-banner";
 import "./dp/set-display";

--- a/src/js/polyfills.js
+++ b/src/js/polyfills.js
@@ -1,8 +1,8 @@
 // Import polyfills for IE11
-import 'core-js'
-import 'mdn-polyfills/CustomEvent'
-import 'mdn-polyfills/Node.prototype.append'
-import 'mdn-polyfills/Node.prototype.remove'
-import 'mdn-polyfills/Element.prototype.closest'
-import 'whatwg-fetch'
-import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
+import "core-js/stable";
+import "mdn-polyfills/CustomEvent";
+import "mdn-polyfills/Node.prototype.append";
+import "mdn-polyfills/Node.prototype.remove";
+import "mdn-polyfills/Element.prototype.closest";
+import "whatwg-fetch";
+import "abortcontroller-polyfill/dist/polyfill-patch-fetch";


### PR DESCRIPTION
### What

The es5 bundle was producing errors in IE11, consequently no javascript on a given page (using the `dp-design-system`) worked. This PR rectifies this. 
- `babel.conf.nomodule.js` matches the [design system's](https://github.com/ONSdigital/design-system/blob/master/babel.conf.nomodule.js)
- Removed import of design system js from `main.js` and created two new import files (`import-ds.js` and `import-ds.es5.js`). `gulpfile.js` now determines which 'base' js to load. Previously, when using the es6 `main.js` from the design system and bundling this file into `es5`, adding polyfills, etc. resulted in several console errors. By using an `es5` file as a base fixes the errors.

### How to review

- Sense check
- You can use browserstack to view a page that uses the `dp-design-system` before and after pulling this branch e.g. census dataset landing page. 
   - You will need to update the `dp-renderer` to view the correct js file locally, there is a [pending PR](https://github.com/ONSdigital/dp-renderer/pull/30) that addresses this

### Who can review

Frontend dev
