### PR TITLE
updated typo

### DIFF
--- a/src/js/dp/search.js
+++ b/src/js/dp/search.js
@@ -40,9 +40,9 @@ filters.forEach((item) => {
 
       // WIP
       // strParams = strParams.replace(/(\&|\?)page=[0-9]*/, '')
-      // document
-      //   .querySelector(".search__pagintion")
-      //   .replaceWith(dom.querySelector(".search__pagintion"));
+      document
+        .querySelector(".search__pagination")
+        .replaceWith(dom.querySelector(".search__pagination"));
     }
   });
 });


### PR DESCRIPTION
### What

updated `search_pagination` style typo

### How to review

when doing a filter on `data -> datasets` only a single pagination item should appear

![image](https://user-images.githubusercontent.com/5684161/150154944-4f4f8528-7f80-467e-99fb-2b9f0b889c5c.png)


### Who can review

anyone

Describe who worked on the changes, so that other people can review.
