### PR TITLE
Feature/styling for flex summary

### DIFF
--- a/src/js/dp/search.js
+++ b/src/js/dp/search.js
@@ -1,4 +1,4 @@
-const searchContainer = document.querySelector('.search__container');
+const searchContainer = document.querySelector(".search__container");
 
 const fetchHtml = async (url) => {
   const response = await fetch(url, {
@@ -8,20 +8,27 @@ const fetchHtml = async (url) => {
       Accept: "application/json",
     }),
   });
-  return response && await response.text();
+  return response && (await response.text());
 };
 
 const replaceWithIEPollyfill = (el1, el2) => {
   // element.replaceWith() is not IE compatible, this is a workaround
-  el1.insertAdjacentElement('beforebegin', el2);
+  el1.insertAdjacentElement("beforebegin", el2);
   el1.parentElement.removeChild(el1);
-}
+};
 
-const switchSearchMarkup = async (strParams, resetPagination = false, scrollToTop = false) => {
+const switchSearchMarkup = async (
+  strParams,
+  resetPagination = false,
+  scrollToTop = false
+) => {
   let theStringParams = strParams;
-  if(resetPagination){
+  if (resetPagination) {
     // reset to page 1 since filtering and sorting will change the length/order of results.
-    theStringParams = theStringParams.replace(new RegExp(`[?&]page\=[^&]+`), "&page=1");
+    theStringParams = theStringParams.replace(
+      new RegExp(`[?&]page\=[^&]+`),
+      "&page=1"
+    );
   }
 
   const responseText = await fetchHtml(`/search${theStringParams}`);
@@ -29,117 +36,145 @@ const switchSearchMarkup = async (strParams, resetPagination = false, scrollToTo
     const dom = new DOMParser().parseFromString(responseText, "text/html");
 
     // update the address bar
-    history.pushState(null, '', `search${theStringParams}`);
+    history.pushState(null, "", `search${theStringParams}`);
 
     replaceWithIEPollyfill(
-      searchContainer.querySelector(".search__results"), 
+      searchContainer.querySelector(".search__results"),
       dom.querySelector(".search__results")
     );
 
     replaceWithIEPollyfill(
-      searchContainer.querySelector(".search__pagination"), 
+      searchContainer.querySelector(".search__pagination"),
       dom.querySelector(".search__pagination")
     );
-    
+
     replaceWithIEPollyfill(
-      searchContainer.querySelector(".search__summary__count"), 
+      searchContainer.querySelector(".search__summary__count"),
       dom.querySelector(".search__summary__count")
     );
-    
+
     initPaginationListeners();
-    
+
     // scroll to the top of the page after the content has been refreshed, to indicate a change has occured
-    if(scrollToTop){
-      const searchResultsSection = searchContainer.querySelector('[aria-label="Search results"]')
-      const resultsSectionOffsetFromTop = searchResultsSection.getBoundingClientRect().top + document.documentElement.scrollTop;
-      window.scrollTo(0, resultsSectionOffsetFromTop)
+    if (scrollToTop) {
+      const searchResultsSection = searchContainer.querySelector(
+        '[aria-label="Search results"]'
+      );
+      const resultsSectionOffsetFromTop =
+        searchResultsSection.getBoundingClientRect().top +
+        document.documentElement.scrollTop;
+      window.scrollTo(0, resultsSectionOffsetFromTop);
     }
   }
-}
+};
 
 const switchCheckbox = (paramsArray) => {
   // get current param
-  let strParams = window.location.search; 
+  let strParams = window.location.search;
 
   // build new param
   paramsArray.map((param) => {
-    if(!('isChecked' in param) || !('filterName' in param)) return;
+    if (!("isChecked" in param) || !("filterName" in param)) return;
     if (param.isChecked) {
       strParams += `&filter=${param.filterName}`;
     } else {
-      strParams = strParams.replace(new RegExp(`(\\&|\\?)filter\=${param.filterName}`), "")
+      strParams = strParams.replace(
+        new RegExp(`(\\&|\\?)filter\=${param.filterName}`),
+        ""
+      );
     }
   });
 
   // make the change to the markup
-  switchSearchMarkup(strParams, true)
-}
+  switchSearchMarkup(strParams, true);
+};
 
-// create listeners for checkboxes controlling eachother
-[...searchContainer.querySelectorAll('.ons-checkboxes__items [aria-controls]')].map(topFilter => {
-  const childrenSelector = topFilter.getAttribute('aria-controls');
-  const theChildren = [...searchContainer.querySelectorAll(`#${childrenSelector} [type=checkbox]`)];
-  if(!childrenSelector) return;
-  topFilter.addEventListener("change", async (e) => {
-      const paramsArray = theChildren.map(item => ({isChecked: e.target.checked, filterName: item.value}));
-      theChildren.map(item => item.checked = e.target.checked);
+if (searchContainer) {
+  // create listeners for checkboxes controlling eachother
+  [
+    ...searchContainer.querySelectorAll(
+      ".ons-checkboxes__items [aria-controls]"
+    ),
+  ].map((topFilter) => {
+    const childrenSelector = topFilter.getAttribute("aria-controls");
+    const theChildren = [
+      ...searchContainer.querySelectorAll(
+        `#${childrenSelector} [type=checkbox]`
+      ),
+    ];
+    if (!childrenSelector) return;
+    topFilter.addEventListener("change", async (e) => {
+      const paramsArray = theChildren.map((item) => ({
+        isChecked: e.target.checked,
+        filterName: item.value,
+      }));
+      theChildren.map((item) => (item.checked = e.target.checked));
       switchCheckbox(paramsArray);
-  });
-  theChildren.map((item) => {
+    });
+    theChildren.map((item) => {
       item.addEventListener("change", async (e) => {
-        switchCheckbox([{isChecked: e.target.checked, filterName: e.target.value}]);
-        topFilter.checked = theChildren.some(x => x.checked);
-      })
-  });    
-});
-
-// create listeners for the sort dropdown
-const sortSelector = searchContainer.querySelector(".ons-input--sort-select");
-if(!!sortSelector) {
-  sortSelector.addEventListener("change", async (e) => {
-    let strParams = window.location.search;
-    // remove old param
-    strParams = strParams.replace(new RegExp(`[?&]sort\=[^&]+`), "")
-    // replace
-    strParams += `&sort=${e.target.value}`;
-    switchSearchMarkup(strParams, true)
-  });
-}
-
-// create listeners for the pagination
-const initPaginationListeners = () => {
-  const paginationItems = searchContainer.querySelectorAll(".ons-pagination__item a[data-target-page]");
-  if(!!paginationItems) {
-    paginationItems.forEach((item) => {
-      item.addEventListener("click", async (e) => {
-        e.preventDefault();
-        let strParams = window.location.search;
-        const { targetPage } = e.target.dataset;
-        if( !targetPage ) return;
-        // remove old param if it's there
-        strParams = strParams.replace(new RegExp(`[?&]page\=[^&]+`), "");
-        // add the new page target
-        strParams += `&page=${targetPage}`;
-        switchSearchMarkup(strParams, false, true)
+        switchCheckbox([
+          { isChecked: e.target.checked, filterName: e.target.value },
+        ]);
+        topFilter.checked = theChildren.some((x) => x.checked);
       });
     });
+  });
+
+  // create listeners for the sort dropdown
+  const sortSelector = searchContainer.querySelector(".ons-input--sort-select");
+  if (!!sortSelector) {
+    sortSelector.addEventListener("change", async (e) => {
+      let strParams = window.location.search;
+      // remove old param
+      strParams = strParams.replace(new RegExp(`[?&]sort\=[^&]+`), "");
+      // replace
+      strParams += `&sort=${e.target.value}`;
+      switchSearchMarkup(strParams, true);
+    });
   }
-}
 
-initPaginationListeners();
+  // create listeners for the pagination
+  const initPaginationListeners = () => {
+    const paginationItems = searchContainer.querySelectorAll(
+      ".ons-pagination__item a[data-target-page]"
+    );
+    if (!!paginationItems) {
+      paginationItems.forEach((item) => {
+        item.addEventListener("click", async (e) => {
+          e.preventDefault();
+          let strParams = window.location.search;
+          const { targetPage } = e.target.dataset;
+          if (!targetPage) return;
+          // remove old param if it's there
+          strParams = strParams.replace(new RegExp(`[?&]page\=[^&]+`), "");
+          // add the new page target
+          strParams += `&page=${targetPage}`;
+          switchSearchMarkup(strParams, false, true);
+        });
+      });
+    }
+  };
 
-// filter menu for mobile
-// if the page is running javascript let's make the filter menus togglable and full-screen when displayed
-const toggleBtns = [...searchContainer.querySelectorAll('.search__filter__mobile-filter-toggle')]
-const filterMenu = searchContainer.querySelector('#search-filter')
-filterMenu.classList.add('js-fullscreen-filter-menu-content', 'hide--sm');
-toggleBtns.map((btn) => {
-  btn.classList.remove('hide');
-  btn.addEventListener('click', () => {
-      if( filterMenu.classList.contains('hide--sm') ) {
-          filterMenu.classList.remove('hide--sm');
+  initPaginationListeners();
+
+  // filter menu for mobile
+  // if the page is running javascript let's make the filter menus togglable and full-screen when displayed
+  const toggleBtns = [
+    ...searchContainer.querySelectorAll(
+      ".search__filter__mobile-filter-toggle"
+    ),
+  ];
+  const filterMenu = searchContainer.querySelector("#search-filter");
+  filterMenu.classList.add("js-fullscreen-filter-menu-content", "hide--sm");
+  toggleBtns.map((btn) => {
+    btn.classList.remove("hide");
+    btn.addEventListener("click", () => {
+      if (filterMenu.classList.contains("hide--sm")) {
+        filterMenu.classList.remove("hide--sm");
       } else {
-          filterMenu.classList.add('hide--sm')
+        filterMenu.classList.add("hide--sm");
       }
-  })
-});
+    });
+  });
+}

--- a/src/scss/dp/_styles.scss
+++ b/src/scss/dp/_styles.scss
@@ -16,6 +16,7 @@
 @import './overrides/components/footer';
 @import './overrides/components/improve-this-page';
 @import './overrides/components/field';
+@import './overrides/components/list';
 
 @import './overrides/design-system/foundations';
 @import './overrides/design-system/components';

--- a/src/scss/dp/overrides/components/_list.scss
+++ b/src/scss/dp/overrides/components/_list.scss
@@ -1,0 +1,17 @@
+.ons-list {
+  &--container {
+    line-height: 1.4rem;
+  }
+  &--truncated {
+    @extend .ons-list;
+  }
+
+  &__item--truncated {
+    @extend .ons-list__item;
+    &:nth-child(3)::after,
+    &:nth-child(6)::after {
+      content: "\a ...";
+      white-space: pre;
+    }
+  }
+}

--- a/src/scss/dp/overrides/design-system/_components.scss
+++ b/src/scss/dp/overrides/design-system/_components.scss
@@ -29,4 +29,18 @@
       border-top-width: 2px !important;
     }
   }
+
+  &-summary {
+    &__item-title.ons-u-pt-s.ons-u-pb-s,
+    &__values.ons-u-pt-s.ons-u-pb-s,
+    &__actions.ons-u-pt-s.ons-u-pb-s {
+      padding-top: 1rem;
+      padding-bottom: 1rem;
+    }
+
+    &__item-title.ons-u-pr-m,
+    &__values.ons-u-pr-m {
+      padding-right: 1.333333rem;
+    }
+  }
 }


### PR DESCRIPTION
### What

- Added styling for flex summary screens ([trello ticket](https://trello.com/c/1OmxfZxg/5499-review-changes-topic-summaries-univariate-datasets))
- Initial styling for truncated lists ([trello ticket](https://trello.com/c/yGcd35VC/5520-truncation))
- Fixing `console.error` bug by adding a guard clause and ran linter
<img width="318" alt="Screenshot 2022-03-09 at 08 43 49" src="https://user-images.githubusercontent.com/19624419/157836754-fb96e42b-85bd-4a9f-9a28-1081201fb1f6.png">

### How to review

- Sense check

### Who can review

Frontend dev
