### PR TITLE
Add styling for compact-search component

### DIFF
--- a/src/scss/dp/overrides/design-system/_components.scss
+++ b/src/scss/dp/overrides/design-system/_components.scss
@@ -1,4 +1,38 @@
 .ons {
+  &-compact-search {
+    border: 1px solid $mine-shaft;
+    border-radius: 3px;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    padding: 1px;
+
+    &:focus-within {
+      box-shadow: 0 0 0 3px $pineapple-yellow, inset 0 0 0 1px $mine-shaft;
+      outline: none;
+    }
+
+    &__input {
+      border: none;
+      line-height: 1rem;
+      font-size: 1rem;
+      font-family: inherit;
+      padding: 0.39rem 0.5rem;
+      width: 100%;
+      appearance: none;
+
+      &:focus {
+        box-shadow: none;
+        outline: none;
+      }
+    }
+
+    &__btn {
+      padding: 0.6rem 1rem;
+      margin: 0 !important;
+    }
+  }
+
   &-metadata__value.ons-u-f-no {
     float: none;
   }


### PR DESCRIPTION
### What

Add styling for a 'compact-search' component [added to dp-renderer](https://github.com/ONSdigital/dp-renderer/pull/67)

Without focus:

<img width="294" alt="Screenshot 2022-03-21 at 16 58 30" src="https://user-images.githubusercontent.com/912770/159321902-e9bd29ce-09db-4604-a57d-838237713518.png">

With focus:

<img width="301" alt="Screenshot 2022-03-21 at 16 57 31" src="https://user-images.githubusercontent.com/912770/159320967-a82e0e77-ed7b-487a-b8e0-3a623d774f63.png">

### How to review

Verify styling changes.

### Who can review

Frontend / Design System developers.
