### PR TITLE
Add utility class to set align-items to baseline

### DIFF
--- a/src/scss/dp/overrides/design-system/_utilities.scss
+++ b/src/scss/dp/overrides/design-system/_utilities.scss
@@ -1,6 +1,14 @@
 // Utility overrides for design system that do not exist elsewhere
 // follow naming convention ons-u...
 
+$alignItems: (
+  fs: flex-start,
+  fe: flex-end,
+  c: center,
+  s: stretch,
+  b: baseline,
+);
+
 .ons-u {
   @include mq(xxs, s) {
     &-fw\@xxs\@s {
@@ -16,6 +24,12 @@
   @for $i from 1 to 10 {
     &-order--#{$i} {
       order: #{$i};
+    }
+  }
+
+  @each $key, $value in $alignItems {
+    &-flex-ai-#{$key} {
+      align-items: #{$value} !important;
     }
   }
 }

--- a/src/scss/dp/overrides/helpers/_utilities.scss
+++ b/src/scss/dp/overrides/helpers/_utilities.scss
@@ -665,3 +665,8 @@ $old-ie: false;
 .clearfix {
     @extend %clearfix;
 }
+
+// Flexbox
+.align-items-baseline {
+    align-items: baseline !important;
+}

--- a/src/scss/dp/overrides/helpers/_utilities.scss
+++ b/src/scss/dp/overrides/helpers/_utilities.scss
@@ -1,4 +1,5 @@
-//_utilities.scss
+// Utilities inherited from Sixteens design system, destined for removal
+// once the transition to the ONS design system is complete.
 
 $old-ie: false;
 
@@ -664,9 +665,4 @@ $old-ie: false;
 // Use as alternative to overflow:hidden
 .clearfix {
     @extend %clearfix;
-}
-
-// Flexbox
-.align-items-baseline {
-    align-items: baseline !important;
 }


### PR DESCRIPTION
### What

A utility class to override `align-items` on flex containers to `baseline`.

### How to review

Verify structure and approach.

### Who can review

Frontend developers
