### PR TITLE
add highlighting

### DIFF
--- a/src/scss/dp/overrides/helpers/_utilities.scss
+++ b/src/scss/dp/overrides/helpers/_utilities.scss
@@ -665,3 +665,10 @@ $old-ie: false;
 .clearfix {
     @extend %clearfix;
 }
+
+// Highlighting - temporary fix while waiting for the design system to include highlighting in their npm package
+.ons-highlight {
+  background-color: $color-highlight;
+  font-style: normal;
+  padding: 0 2px;
+}


### PR DESCRIPTION
### What

Add highlighting for search. This is a temporary fix while we wait for the design system to update their npm package with the highlight styling. This has been raised with the design system team and they have created a ticket for this.  

### How to review

See that search results are now returned with highlighting. 
<img width="1137" alt="Screenshot 2022-04-01 at 09 42 05" src="https://user-images.githubusercontent.com/16807393/161228308-2e70c326-16d2-4abc-b991-3e80780acfe8.png">


### Who can review

Anyone
