### PR TITLE
Feedback layout accommodates Welsh translations correctly on all display sizes

### DIFF
--- a/src/scss/dp/overrides/components/_improve-this-page.scss
+++ b/src/scss/dp/overrides/components/_improve-this-page.scss
@@ -3,10 +3,41 @@
     background-color: $astral;
     color: $white;
     padding: 10px 15px 10px;
+    display: flex;
+    justify-content: space-between;
+
+    @include breakpoint(sm) {
+      flex-wrap: wrap;
+    }
 
     a {
       color: $white;
       display: inline-block;
+    }
+  }
+
+  &__prompt_left {
+    flex-grow: 1;
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    padding-right: 2rem;
+
+    @include breakpoint(sm) {
+      padding: 0;
+    }
+
+    a {
+      white-space: nowrap;
+    }
+  }
+
+  &__prompt_right {
+    padding-left: 2rem;
+
+    @include breakpoint(sm) {
+      padding: 0;
+      margin: $col 0 $baseline 0;
     }
   }
 
@@ -99,15 +130,6 @@
 
   &__page-is-useful-button {
     margin-right: 0.2em;
-  }
-
-  &__anything-wrong {
-    float: right;
-
-    @include breakpoint(sm) {
-      float: none;
-      margin: $col 0 $baseline 0;
-    }
   }
 }
 

--- a/src/scss/dp/overrides/components/_improve-this-page.scss
+++ b/src/scss/dp/overrides/components/_improve-this-page.scss
@@ -10,6 +10,10 @@
       flex-wrap: wrap;
     }
 
+    h3 {
+      margin-bottom: 0;
+    }
+
     a {
       color: $white;
       display: inline-block;


### PR DESCRIPTION
### What

Layout accommodates Welsh translations correctly where previously they clashed and overlapped.

#### English

Desktop

<img width="1042" alt="Screenshot 2022-04-08 at 16 30 16" src="https://user-images.githubusercontent.com/912770/162497915-b973bb50-cb7e-4c78-9d13-b3c6bc48b7e6.png">

Tablet

<img width="754" alt="Screenshot 2022-04-08 at 16 30 04" src="https://user-images.githubusercontent.com/912770/162497937-45d6baae-2b89-40c0-8446-b2c19ebba1cb.png">

Mobile

<img width="366" alt="Screenshot 2022-04-08 at 16 29 50" src="https://user-images.githubusercontent.com/912770/162497994-08ef3671-9ebf-46e0-b014-534614ca2253.png">


#### Welsh

Desktop

<img width="1055" alt="Screenshot 2022-04-08 at 16 28 51" src="https://user-images.githubusercontent.com/912770/162498047-465a8da0-3a4b-475d-b6a1-549af776c9bc.png">

Tablet

<img width="759" alt="Screenshot 2022-04-08 at 16 29 21" src="https://user-images.githubusercontent.com/912770/162498075-75b35339-0866-4b9f-93f3-1b8bfa3bb826.png">

Mobile

<img width="361" alt="Screenshot 2022-04-08 at 16 29 29" src="https://user-images.githubusercontent.com/912770/162498100-343b57cb-dea8-43e0-9827-c43da84c97d7.png">


### How to review

Verify structure and approach.

### Who can review

Frontend / Design System developers
