### PR TITLE
Release Type radio filters autosubmit on change

### DIFF
--- a/src/js/dp/release-calendar.js
+++ b/src/js/dp/release-calendar.js
@@ -1,0 +1,30 @@
+import { findNode } from "../utilities";
+
+document.addEventListener("DOMContentLoaded", function () {
+  function releaseTypeAutoSubmit(formSelector) {
+    function onChangeHandler(event) {
+      if (
+        event.target.nodeName === "INPUT" &&
+        event.target.classList.contains("ons-radio__input")
+      ) {
+        event.target.form.submit();
+      }
+    }
+
+    const nodeReleaseTypeForm = findNode(formSelector);
+    if (!nodeReleaseTypeForm) {
+      console.warn("releaseTypeAutoSubmit() No form found");
+      return;
+    }
+
+    const nodeRadioSet = findNode(nodeReleaseTypeForm, ":scope .ons-radios__items");
+    if (!nodeRadioSet) {
+      console.warn("releaseTypeAutoSubmit() No radio set found");
+      return;
+    }
+
+    nodeRadioSet.addEventListener("change", onChangeHandler);
+  }
+
+  releaseTypeAutoSubmit(".release-calendar__filters .filters__release-type");
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5,3 +5,4 @@ import "./dp/viewport-size";
 import "./dp/nav";
 import "./dp/improve-this-page";
 import "./dp/search";
+import "./dp/release-calendar";

--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -1,6 +1,18 @@
 // Google Tag Manager
 export const gtmDataLayerPush = (obj) => {
-    if('dataLayer' in window) {
+    if ('dataLayer' in window) {
         window.dataLayer.push(obj);
     }
+}
+
+export const findNode = (rootNode, selector) => {
+    if (typeof rootNode === "string") {
+        selector = rootNode;
+        rootNode = document;
+    }
+
+    const matches = rootNode.querySelectorAll(selector);
+    return matches
+        ? matches[0]
+        : null;
 }


### PR DESCRIPTION
### What

Release Type filter radio buttons on the Release Calendar auto-submit the form when selecting a different radio button.

- JavaScript enabled 

<img width="346" alt="Screenshot 2022-04-27 at 16 13 39" src="https://user-images.githubusercontent.com/912770/165551687-ca9768ed-0225-4333-a4b6-d3b2e0c2d79b.png">

- JavaScript disabled

<img width="347" alt="Screenshot 2022-04-27 at 16 13 50" src="https://user-images.githubusercontent.com/912770/165551697-c77ed0b4-c1ac-4286-bcbf-4b43277ba8d4.png">

### How to review

Code review. Can be demoed against Release Calendar frontend controller on request.

### Who can review

Frontend / Design System developers.
