### PR TITLE
added JS functionality to show search page loading message

### DIFF
--- a/src/js/dp/search.js
+++ b/src/js/dp/search.js
@@ -46,8 +46,9 @@ if (searchContainer) {
     }
 
     // if it takes more than 500ms to retreive results, show a loading message
-    var loadingPanel = setTimeout(() => {
-      document.querySelector('#results-loading').classList.remove('hide')
+    const resultsLoader = document.querySelector('#results-loading');
+    setTimeout(() => {
+      if (resultsLoader) resultsLoader.classList.remove('hide');
       if (scrollToTop) scrollToTopOfSearch();
     }, 500);
 
@@ -56,13 +57,9 @@ if (searchContainer) {
     if (scrollToTop) scrollToTopOfSearch();
 
     if (!responseText) {
-      const pTag = document.querySelector('#results-loading p');
-      pTag.innerText = pTag.dataset.errorMessage;
+      const pTag = resultsLoader.querySelector('p');
+      if(pTag) pTag.innerText = pTag.dataset.errorMessage;
     } else {
-      // cancel a pending loading message and hide it if it's already showing
-      clearTimeout(loadingPanel);
-      document.querySelector('#results-loading').classList.remove('hide')
-      
       const dom = new DOMParser().parseFromString(responseText, "text/html");
 
       // update the address bar


### PR DESCRIPTION
### What

A loading indicator to show results are taking a while to arrive, there is a 500ms delay to avoid content jumping for users with fast connections.

> As a website user, with a slow internet connection
> I want to know that my search worked
> so that I am reassured and do not refresh
> 
> 

Affects: https://github.com/ONSdigital/dp-frontend-search-controller/pull/117

https://trello.com/c/08BLV9Xr/1058-add-loading-indicator-to-search-results-page?filter=label:Front%20End

### How to review

Read or pull. Don't forget the dp-frontend-search-controller counterpart above.

### Who can review

Anyone.
