### PR TITLE
Add branding support in Release heading

### DIFF
--- a/src/scss/dp/overrides/components/_release.scss
+++ b/src/scss/dp/overrides/components/_release.scss
@@ -1,4 +1,13 @@
 .release {
+  h1 {
+    display: flex;
+    justify-content: flex-start;
+
+    & > img {
+      height: 59px;
+    }
+  }
+
   .about-the-data {
     .welsh-statistic > img {
       height: 44px;


### PR DESCRIPTION
### What

Adds support for National Statistics branding of Release titles

<img width="1043" alt="Screenshot 2022-05-06 at 15 34 25" src="https://user-images.githubusercontent.com/912770/167154473-eba57ea7-5ac5-4d1d-a055-d8bd4833b70d.png">

### How to review

Code review

### Who can review

Frontend / design system developers

