### PR TITLE
Only search for release type form on a release calendar

### DIFF
--- a/src/js/dp/release-calendar.js
+++ b/src/js/dp/release-calendar.js
@@ -26,5 +26,7 @@ document.addEventListener("DOMContentLoaded", function () {
     nodeRadioSet.addEventListener("change", onChangeHandler);
   }
 
-  releaseTypeAutoSubmit(".release-calendar__filters .filters__release-type");
+  if (findNode(".release-calendar")) {
+    releaseTypeAutoSubmit(".release-calendar__filters .filters__release-type");
+  }
 });


### PR DESCRIPTION
### What

Prevent warning for missing release type form appearing on any page not expected to carry one.

### How to review

- Run dp-design-system in a separate shell with `make debug`
- Run Release Calendar frontend with `make debug`
- Ensure switching between Release types (published, upcoming, cancelled) continues to function correctly
- Select a Release and ensure the warning for a missing release type form no longer appears in the development console

### Who can review

Frontend / design system developers
