### PR TITLE
Bump design system to 49.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,9 +1253,9 @@
       }
     },
     "@ons/design-system": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ons/design-system/-/design-system-45.2.2.tgz",
-      "integrity": "sha512-XNVV1LH0tbIwDqOy2txGSAAHGITJ1W9hqR5StSZW2b79SMMrjrH27KCYkuGBb3n2Pr8Lx2hBNDLOk+k5I/SE8w=="
+      "version": "49.1.0",
+      "resolved": "https://registry.npmjs.org/@ons/design-system/-/design-system-49.1.0.tgz",
+      "integrity": "sha512-zDGIM8Rv+8BwB5Qcqyhkl4M5EBxBxhTxTZL5k9L4gLadUN/ltEwLCYq1WD0xSdv0AMEZU8ocNHjKFFKBNboftw=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/ONSdigital/dp-design-system#readme",
   "dependencies": {
-    "@ons/design-system": "^45.1.0",
+    "@ons/design-system": "^49.1.0",
     "core-js": "^3.18.3",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -13,7 +13,6 @@
 @import '../../node_modules/@ons/design-system/scss/settings/census';
 
 // ONS Design System Components relevant to the ONS Website
-@import '../../node_modules/@ons/design-system/components/articles/articles';
 @import '../../node_modules/@ons/design-system/components/autosuggest/autosuggest';
 @import '../../node_modules/@ons/design-system/components/breadcrumbs/breadcrumbs';
 @import '../../node_modules/@ons/design-system/components/button/button';
@@ -24,7 +23,7 @@
 @import '../../node_modules/@ons/design-system/components/collapsible/collapsible';
 @import '../../node_modules/@ons/design-system/components/content-pagination/content-pagination';
 @import '../../node_modules/@ons/design-system/components/download-resources/download-resources';
-@import '../../node_modules/@ons/design-system/components/downloads/downloads';
+@import '../../node_modules/@ons/design-system/components/document-list/document-list';
 @import '../../node_modules/@ons/design-system/components/external-link/external-link';
 @import '../../node_modules/@ons/design-system/components/feedback/feedback';
 @import '../../node_modules/@ons/design-system/components/field/field-group';


### PR DESCRIPTION
### What

Bump design system to 49.1.0
- includes disabled checkboxes needed for search work
- remove `/components/articles` and `/components/download-links` replaced with `/components/download-resources` in `49.1.0`

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
