### PR TITLE
Apply styling to bulletin document type

### DIFF
--- a/src/scss/dp/_styles.scss
+++ b/src/scss/dp/_styles.scss
@@ -19,6 +19,7 @@
 @import "./overrides/components/list";
 @import "./overrides/components/release-calendar";
 @import "./overrides/components/release";
+@import "./overrides/components/bulletin";
 
 @import "./overrides/design-system/foundations";
 @import "./overrides/design-system/components";

--- a/src/scss/dp/overrides/components/_bulletin.scss
+++ b/src/scss/dp/overrides/components/_bulletin.scss
@@ -1,0 +1,5 @@
+.bulletin {
+  &__document-type {
+    color: $color-grey-75;
+  }
+}


### PR DESCRIPTION
### What

Style document type ("Bulletin") in `#707071` / `$color-grey-75`

<img width="684" alt="Screenshot 2022-05-24 at 16 04 12" src="https://user-images.githubusercontent.com/912770/170068667-f4bc6089-8c40-4276-96bd-051d0879cbc4.png">

### How to review

Sense check

### Who can review

Frontend / design system developers
