### PR TITLE
make font smaller

### DIFF
--- a/src/scss/dp/overrides/components/_emergency-banner.scss
+++ b/src/scss/dp/overrides/components/_emergency-banner.scss
@@ -32,7 +32,6 @@
 
     &__heading {
         font-weight: 700;
-        font-size: 1.7rem;
         line-height: $base-line-height;
         margin: 0;
         padding: 0;


### PR DESCRIPTION
### What

Remove font size on banner heading so heading is default 26px for `h2`

### How to review

See that font size is removed. 

### Who can review

Anyone
