### PR TITLE
Remove left padding on Release Calendar filter heading

### DIFF
--- a/src/scss/dp/overrides/components/_release-calendar.scss
+++ b/src/scss/dp/overrides/components/_release-calendar.scss
@@ -2,7 +2,7 @@
   &__filters {
     &__heading {
       line-height: 1.3rem;
-      padding: 0.39rem 2rem 0.39rem 0.5rem;
+      padding: 0.39rem 2rem 0.39rem 0;
       margin-bottom: 1rem;
 
       &--margin-one-fix {


### PR DESCRIPTION
### What

Remove left padding on Release Calendar filter heading

<img width="653" alt="Screenshot 2022-06-23 at 19 35 58" src="https://user-images.githubusercontent.com/912770/175371656-7abaa449-4bb0-4852-99c0-9f3ac6e71d54.png">

### How to review

Sense check

### Who can review

Front end / design system developers
