### PR TITLE
Fix positioning and mobile sizing of National Statistics logo on Release title

### DIFF
--- a/src/scss/dp/overrides/components/_release.scss
+++ b/src/scss/dp/overrides/components/_release.scss
@@ -5,7 +5,7 @@
 
   h1 {
     display: flex;
-    justify-content: flex-start;
+    justify-content: space-between;
 
     .national-statistics {
       &__logo {
@@ -14,6 +14,15 @@
         width: 59px;
         min-height: 59px;
         min-width: 59px;
+      }
+
+      @media (max-width: 739px) {
+        &__logo {
+          height: 41px;
+          width: 41px;
+          min-height: 41px;
+          min-width: 41px;
+        }
       }
     }
   }


### PR DESCRIPTION
### What

National Statistics logo now stuck to right margin, and shrinks down to matching heading text height on mobile.

Desktop
<img width="1018" alt="Screenshot 2022-06-24 at 12 57 25" src="https://user-images.githubusercontent.com/912770/175537734-e8d24697-b323-4c0f-a5da-3f874a534321.png">
<img width="1031" alt="Screenshot 2022-06-24 at 12 57 15" src="https://user-images.githubusercontent.com/912770/175537745-35cc8274-1923-4ae8-b3f0-24b2262015b3.png">

Mobile
<img width="372" alt="Screenshot 2022-06-24 at 13 24 55" src="https://user-images.githubusercontent.com/912770/175537669-33f79ed1-ea12-4e46-9a15-015963e15e35.png">
<img width="373" alt="Screenshot 2022-06-24 at 13 25 41" src="https://user-images.githubusercontent.com/912770/175537677-818fa155-bd7a-4eec-9341-ff8090a18ee5.png">


### How to review

Sense check

### Who can review

Frontend / design system developers
