### PR TITLE
Feature/adding full width utility class

### DIFF
--- a/src/scss/dp/overrides/design-system/_utilities.scss
+++ b/src/scss/dp/overrides/design-system/_utilities.scss
@@ -10,6 +10,9 @@ $alignItems: (
 );
 
 .ons-u {
+  &-fw {
+    width: 100%;
+  }
   @include mq(xxs, s) {
     &-fw\@xxs\@s {
       width: 100% !important;


### PR DESCRIPTION
### What

Added `ons-u-fw` with value `width: 100%` outside of existing media query as the `ons-u-fw@xxs@s` are within a media query and have the dreaded `!important` specificity flag

### How to review

Sense check

### Who can review

Design system devs
