### PR TITLE
Add ons-sticker class

### DIFF
--- a/src/scss/dp/overrides/design-system/_components.scss
+++ b/src/scss/dp/overrides/design-system/_components.scss
@@ -72,6 +72,12 @@
     }
   }
 
+  &-sticker {
+    background-color: $color-grey-15;
+    border: 1px solid  $color-grey-35;
+    padding: 0.3rem 0.5rem;
+  }
+
   &-summary {
     &__item-title.ons-u-pt-s.ons-u-pb-s,
     &__values.ons-u-pt-s.ons-u-pb-s,


### PR DESCRIPTION
### What

The 'sticker' in this example is the word 'LATEST' styled to make it more prominent, as in this case for conveying document status.

<img width="356" alt="Screenshot 2022-06-27 at 16 57 57" src="https://user-images.githubusercontent.com/912770/175982810-066c1e5a-b630-414f-a6bd-39208c4f877d.png">

Example usage:

```html
 <span class="ons-sticker ons-u-fs-s--b ons-u-mr-l">LATEST</span>
```

The font size and margin have been deliberately omitted from the sticker styling to allow it to be easily re-used in different circumstances.

### How to review

Sense check

### Who can review

Design system developers
