### PR TITLE
Feature/article printing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,7 +1701,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "asn1.js": {
@@ -3904,6 +3904,16 @@
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "requires": {
             "is-glob": "^4.0.1"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
           }
         },
         "is-glob": {

--- a/src/js/dp/bulletin.js
+++ b/src/js/dp/bulletin.js
@@ -1,0 +1,33 @@
+import { findNode } from "../utilities";
+
+document.addEventListener("DOMContentLoaded", function () {
+  function attachAction(actionsList, selector, handler) {
+    const actionNode = findNode(
+      actionsList,
+      `:scope ${selector}`
+    );
+    if (!actionNode) {
+      console.warn(`attachAction() No node found for "${selector}"`);
+      return;
+    }
+
+    actionNode.addEventListener("click", handler);
+  }
+
+  function attachPageActions(actionsListSelector) {
+    const actionsList = findNode(actionsListSelector);
+    if (!actionsList) {
+      console.warn("attachPageActions() No actions list found");
+      return;
+    }
+
+    attachAction(actionsList, ".page-action--print", (event) => {
+      event.preventDefault();
+      window.print();
+    });
+  }
+
+  if (findNode(".bulletin")) {
+    attachPageActions(".bulletin .page-actions");
+  }
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,6 +4,7 @@ import "./dp/set-display";
 import "./dp/viewport-size";
 import "./dp/nav";
 import "./dp/improve-this-page";
+import "./dp/bulletin";
 import "./dp/search";
 import "./dp/release-calendar";
 import "./dp/copy-link";

--- a/src/scss/dp/overrides/components/_bulletin.scss
+++ b/src/scss/dp/overrides/components/_bulletin.scss
@@ -1,11 +1,78 @@
 .bulletin {
+  .ons-grid {
+    .ons-grid__col {
+      @media print {
+        display: block;
+        width: 100%;
+        max-width: 100%;
+        position: initial;
+        padding: 0;
+      }
+    }
+  }
+
   &__document-type {
     color: $color-grey-75;
   }
 
-  .page-action__icon--no-roundel > svg {
-    margin: 0.25rem !important;
-    height: 1.5rem;
-    width: 1.5em;
+  .status-header {
+    .ons-list__item {
+      @media print {
+        vertical-align: baseline;
+      }
+    }
+
+    .version-link {
+      @media print {
+        display: none;
+      }
+    }
+  }
+
+  .content-body {
+    .content-length-toggle {
+      @media print {
+        display: none;
+      }
+    }
+
+    @media print {
+      section {
+        h2, h3 {
+          break-inside: avoid;
+          break-after: avoid-page;
+        }
+
+        p {
+          orphans: 2;
+          widows: 2;
+        }
+
+        a {
+          text-decoration: none;
+        }
+
+        a::after {
+          content: ' (' attr(href) ')';
+          color: initial;
+          overflow-wrap: break-word;
+          word-wrap: break-word;
+          word-break: break-word;
+          hyphens: none;
+        }
+      }
+    }
+  }
+
+  .page-actions {
+    @media print {
+      display: none;
+    }
+
+    .page-action__icon--no-roundel > svg {
+      margin: 0.25rem !important;
+      height: 1.5rem;
+      width: 1.5em;
+    }
   }
 }

--- a/src/scss/dp/overrides/components/_footer.scss
+++ b/src/scss/dp/overrides/components/_footer.scss
@@ -1,3 +1,9 @@
+@media print {
+  footer.print--hide {
+    display: none;
+  }
+}
+
 .footer {
   background-color: $color-grey-100;
   color: $white;

--- a/src/scss/dp/overrides/components/_header.scss
+++ b/src/scss/dp/overrides/components/_header.scss
@@ -3,6 +3,12 @@
 // PRIMARY NAVIGATION
 
 .primary-nav {
+  @media print {
+    &.print--hide {
+      display: none;
+    }
+  }
+
   background-color: $abbey;
   position: relative;
 
@@ -390,6 +396,12 @@
   &--separator {
     background-color: $ship-grey;
     height: 2px;
+  }
+
+  @media print {
+    .print--hide {
+      display: none;
+    }
   }
 }
 

--- a/src/scss/dp/overrides/components/_search.scss
+++ b/src/scss/dp/overrides/components/_search.scss
@@ -1,4 +1,10 @@
 .search {
+  @media print {
+    &.print--hide {
+      display: none;
+    }
+  }
+
   @include breakpoint(sm) {
     background-color: $abbey;
   }
@@ -8,18 +14,18 @@
     font-size: 1.41rem;
     height: 80px;
   }
-  
+
   &__summary {
     width: 100%;
     padding: ($baseline * 3) 0 ($baseline * 3);
-    
+
     @include breakpoint(sm) {
       padding: ($baseline * 2) 0 ($baseline * 2);
     }
-    
+
     .base-font {
       font-size: 2rem;
-        
+
       @include breakpoint(sm) {
         font-size: 1.25rem;
       }
@@ -39,7 +45,7 @@
       display: block;
       margin-top: ($baseline * 3);
     }
-    
+
     &__generic {
       @extend .base-font;
       font-weight: 300;
@@ -89,10 +95,10 @@
         line-height: ($baseline * 8);
       }
     }
-    
+
     &__content {
       margin-top: $grid-gutters;
-      
+
       &__archive-info {
         margin-top: ($baseline * 4);
       }
@@ -116,7 +122,7 @@
   &__sort {
     height: ($baseline * 8);
     border-bottom: 1px solid $iron;
-    
+
     @include breakpoint(sm) {
       height: auto;
       margin: $baseline 0;
@@ -137,12 +143,12 @@
 
       @include breakpoint(sm) {
         display: flex;
-        
+
         label {
           margin: 0 0.25rem 0 0;
           border-bottom: none;
         }
-  
+
         select {
           flex-grow: 1;
         }
@@ -172,7 +178,7 @@
 
       h3 {
         margin-bottom: $baseline;
-        
+
         & a {
           text-decoration: none;
         }
@@ -231,7 +237,7 @@
       margin: 0 0 ($baseline * 2) 0;
       padding: 0;
       display: inline-block;
-      
+
       margin-bottom: 10rem;
       @include breakpoint(sm) {
         margin-bottom: 5rem;
@@ -321,21 +327,21 @@
     background-color: $primary;
     height: ($baseline * 6);
     position: relative;
-    
+
     &:hover,
     &:focus {
       background-color: darken($primary, 8%);
     }
-    
+
     &:focus {
       outline: 3px solid $carrot;
     }
-    
+
     & > * {
       display: flex;
       justify-content: center;
     }
-    
+
     @if $old-ie == false {
       @include breakpoint(sm) {
         width: 20%;
@@ -344,19 +350,19 @@
         padding-right: calc($col/2);
       }
     }
-    
+
     &--results-page {
       height: ($baseline * 5);
       padding-top: calc($baseline / 2);
     }
-    
+
     &--body {
       height: 52px;
       width: 52px;
       margin-top: -2px;
       float: left;
     }
-    
+
     &--no-results {
       width: ($baseline * 5);
       height: ($baseline * 5);

--- a/src/scss/dp/overrides/design-system/_components.scss
+++ b/src/scss/dp/overrides/design-system/_components.scss
@@ -1,4 +1,16 @@
 .ons {
+  &-breadcrumb {
+    @media print {
+      display: none;
+    }
+  }
+
+  &-phase-banner {
+    @media print {
+      display: none;
+    }
+  }
+
   &-compact-search {
     border: 1px solid $mine-shaft;
     border-radius: 3px;
@@ -36,11 +48,24 @@
   &-metadata__value.ons-u-f-no {
     float: none;
   }
+
   &-toc-container {
     border-bottom: none;
     margin-bottom: 0;
     padding-bottom: 0;
+
+    @media print {
+      .ons-toc {
+        .ons-list {
+          .ons-list__item > a {
+            text-decoration: none;
+            color: inherit;
+          }
+        }
+      }
+    }
   }
+
   &-table {
     &__header.ons-u-pb-s {
       padding-bottom: 1rem;

--- a/src/scss/dp/overrides/design-system/_utilities.scss
+++ b/src/scss/dp/overrides/design-system/_utilities.scss
@@ -39,4 +39,13 @@ $alignItems: (
   &-tt-l {
     text-transform: lowercase;
   }
+
+  &-us-no {
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Old versions of Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
+  }
 }


### PR DESCRIPTION
### What

Globally
- Hides the header (except the ONS logo) and the footer when printing
- Adds a utility class `ons-u-us-no` to disable text selection (user selection hence `us`), for example on buttons and other interactive elements

Bulletin
- Hides actions that are only relevant on screen when printing 
- Adopts a single column layout when printing to make the best use of space on the page
- Shows the URLs of links in full when printing

### How to review

Sanity check and/or ask for a demo on the bulletin frontend.

### Who can review

Frontend / design system developers
