### PR TITLE
make message appear after request completes

### DIFF
--- a/src/js/dp/improve-this-page.js
+++ b/src/js/dp/improve-this-page.js
@@ -134,7 +134,6 @@ function initFeedbackRequestHandler(form, path, feedbackFormHeader, feedbackMess
   );
   request.onreadystatechange = function () {
     if (request.readyState === XMLHttpRequest.DONE) {
-      feedbackFormHeader.classList.toggle("js-hidden");
       const status = request.status;
       if (status === 0 || (status >= 200 && status < 400)) {
         feedbackFormHeader.innerHTML = feedbackMessage;
@@ -144,6 +143,7 @@ function initFeedbackRequestHandler(form, path, feedbackFormHeader, feedbackMess
         );
         feedbackFormHeader.innerHTML = feedbackMessageError;
       }
+      feedbackFormHeader.classList.toggle("js-hidden");
     }
   };
   return { request, serializedData };

--- a/src/js/dp/improve-this-page.js
+++ b/src/js/dp/improve-this-page.js
@@ -119,7 +119,6 @@ document.addEventListener("DOMContentLoaded", function () {
       if (feedbackForm) {
         feedbackForm.classList.add("js-hidden");
       }
-      feedbackFormHeader.classList.toggle("js-hidden");
       request.send(serializedData);
     });
   }
@@ -135,6 +134,7 @@ function initFeedbackRequestHandler(form, path, feedbackFormHeader, feedbackMess
   );
   request.onreadystatechange = function () {
     if (request.readyState === XMLHttpRequest.DONE) {
+      feedbackFormHeader.classList.toggle("js-hidden");
       const status = request.status;
       if (status === 0 || (status >= 200 && status < 400)) {
         feedbackFormHeader.innerHTML = feedbackMessage;


### PR DESCRIPTION
### What

NVDA on Chrome reading out old content which is displayed on page load instead of success message after a user submits the feedback partial while on the "No" or "Can't find what you're looking for?" on /census and /search pages. Error is at the 6 second mark.  

https://user-images.githubusercontent.com/16807393/183058850-42e49a19-8558-48f8-88fb-7f02d27e17bc.mov

### How to review

Pull this branch, [this dp-renderer branch](https://github.com/ONSdigital/dp-renderer/pull/114) and [this feedback-controller branch](https://github.com/ONSdigital/dp-frontend-feedback-controller/pull/23). See that only the success message is loaded on the page (and not the old content). 

### Who can review

Frontend dev
