### PR TITLE
Corrections for banner not displaying properly on certain pages

### DIFF
--- a/src/scss/dp/overrides/components/_service-message.scss
+++ b/src/scss/dp/overrides/components/_service-message.scss
@@ -7,17 +7,26 @@
     }
 
     &__body {
-        display: flex;
-        display: -ms-flexbox;
-        padding-bottom: 8px
+
+        display: inline-block;
+        padding-top: $baseline;
+        margin-left: $col;
+
+        @include breakpoint(sm) {
+            padding-top: 0px;
+            margin-left: 0px;
+            display: block;
+        }
     }
 
     &__icon {
             vertical-align: middle;
             position: relative;
-
-            @include breakpoint(sm) {
-                display: none;
+            
+            &.icon {
+                @include breakpoint(sm) {
+                    display: none;
+                }
             }
     }
 }


### PR DESCRIPTION
Corrections for banner not displaying properly on certain pages, e.g. census dataset landing page

### What

For pages that don't use Sixteens the banner was not showing properly, these changes replicate the CSS in Sixteens.

### How to review

No special instructions

### Who can review

Anyone.
