### PR TITLE
Feature/changing dimensions styling

### DIFF
--- a/src/scss/dp/_styles.scss
+++ b/src/scss/dp/_styles.scss
@@ -10,7 +10,7 @@
 @import "./overrides/components/button";
 @import "./overrides/components/nav";
 @import "./overrides/components/cookies-banner";
-@import "./overrides/components/coverage";
+@import "./overrides/components/filter-flex";
 @import "./overrides/components/language-toggle";
 @import "./overrides/components/header";
 @import "overrides/components/search";

--- a/src/scss/dp/overrides/components/_filter-flex.scss
+++ b/src/scss/dp/overrides/components/_filter-flex.scss
@@ -1,4 +1,5 @@
-.coverage {
+.coverage,
+.dimension {
   &-search {
     &__results {
       display: flex;
@@ -15,6 +16,11 @@
       .ons-btn__inner {
         padding: 0.3em 0.7em;
       }
+
+      & .ons-collapsible__content {
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
     }
   }
   &-selection {
@@ -24,6 +30,16 @@
     &__selected .ons-btn__inner {
       padding: 0.5em 0.666667em 0.666667em 0.666667em;
       box-shadow: none;
+    }
+  }
+}
+
+@include mq(xxs, s) {
+  .dimension-search__results {
+    align-items: flex-start !important;
+
+    & .ons-collapsible__content {
+      margin-right: -3rem;
     }
   }
 }


### PR DESCRIPTION
### What

- Renamed file to be more generic
- Additional styling required to display the 'change dimensions' page on the filter/flex user journey

### How to review

- Sense check
- Image review

<img width="788" alt="change dimensions page" src="https://user-images.githubusercontent.com/19624419/202669927-ecb92e86-417f-4220-baed-c4b068cf7216.png">

N.B. Ignore the 'netlify' failure, it is no longer required and someone with admin rights needs to remove it from the repo

### Who can review

Frontend dev
