### PR TITLE
remove topics when checkbox disabled

### DIFF
--- a/src/js/dp/search.js
+++ b/src/js/dp/search.js
@@ -204,7 +204,7 @@ if (searchContainer) {
     const childrenSelector = topicFilter.getAttribute("aria-controls");
     const theChildren = [
         ...searchContainer.querySelectorAll(
-            `#${childrenSelector} [type=checkbox]:not(input:disabled)`
+            `#${childrenSelector} [type=checkbox]`
         ),
     ];
     if (!childrenSelector) return;


### PR DESCRIPTION
### What

Currently deselecting the "Census" checkbox on search only removes topics that are not disabled. All topics including disabled topics must be removed from the url when a user deselects "Census".

### How to review

See that all topics are removed from the url params

### Who can review

!me
