### PR TITLE
Fixed error to do with missing js-cookies-banner-form

### DIFF
--- a/src/js/dp/cookies-banner.js
+++ b/src/js/dp/cookies-banner.js
@@ -10,9 +10,7 @@ const encodedCookiesPolicy = '%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D'
 const cookiesPath = '/'
 
 function determineWhetherToRenderBanner() {
-  const cookiesAreNotSet = !cookiesSet || userIsOnCookiesPreferencesPage()
-
-  if (cookiesAreNotSet) {
+  if (!cookiesSet && !userIsOnCookiesPreferencesPage()) {
     cookiesBanner.classList.remove('cookies-banner--hidden')
     initCookiesBanner()
   }


### PR DESCRIPTION
### What

Changed the conditional on whether to render the banner. Previously caused issue where even if you were on the references page it would try and render the banner which this service does not have access to that template anyway.

### How to review

LGTM.

### Who can review

Anyone.