### PR TITLE
Feature/update data aggregation

### DIFF
--- a/src/js/dp/data-aggregation.js
+++ b/src/js/dp/data-aggregation.js
@@ -385,7 +385,10 @@ if (searchContainer) {
       '#lastUpdatedSelect',
     ),
   ].forEach((topFilter) => {
-    topFilter.addEventListener('input', async () => {
+    topFilter.addEventListener("input", () => handleFilterChange(topFilter));
+    handleFilterChange(topFilter);
+
+    async function handleFilterChange() {
       const element = document.getElementById('dateFilters');
       if (topFilter.value === 'custom') {
         if (element.classList.contains('hidden')) {
@@ -453,6 +456,6 @@ if (searchContainer) {
           switchDate(paramsArray);
         }
       }
-    });
+    }
   });
 }

--- a/src/js/dp/data-aggregation.js
+++ b/src/js/dp/data-aggregation.js
@@ -58,9 +58,9 @@ if (searchContainer) {
           noResultsMessage.classList.remove('hide');
         }
         searchContainer.querySelector('#results > ul').innerHTML = '';
-        const searchPagination = searchContainer.querySelector('.search__pagination')
+        const searchPagination = searchContainer.querySelector('.search__pagination');
         if (searchPagination) {
-          searchPagination.innerHTML = "";
+          searchPagination.innerHTML = '';
         }
         searchContainer.querySelector('.search__summary__count').innerText = '0';
       } else {
@@ -385,9 +385,6 @@ if (searchContainer) {
       '#lastUpdatedSelect',
     ),
   ].forEach((topFilter) => {
-    topFilter.addEventListener("input", () => handleFilterChange(topFilter));
-    handleFilterChange(topFilter);
-
     async function handleFilterChange() {
       const element = document.getElementById('dateFilters');
       if (topFilter.value === 'custom') {
@@ -457,5 +454,8 @@ if (searchContainer) {
         }
       }
     }
+
+    topFilter.addEventListener('input', () => handleFilterChange(topFilter));
+    handleFilterChange(topFilter);
   });
 }

--- a/src/js/dp/data-aggregation.js
+++ b/src/js/dp/data-aggregation.js
@@ -58,7 +58,10 @@ if (searchContainer) {
           noResultsMessage.classList.remove('hide');
         }
         searchContainer.querySelector('#results > ul').innerHTML = '';
-        searchContainer.querySelector('.search__pagination').innerHTML = '';
+        const searchPagination = searchContainer.querySelector('.search__pagination')
+        if (searchPagination) {
+          searchPagination.innerHTML = "";
+        }
         searchContainer.querySelector('.search__summary__count').innerText = '0';
       } else {
         replaceWithIEPolyfill(


### PR DESCRIPTION
### What

This was to fix and add functionality to the 'last updated' selected on the aggregation pages, specifically the time series tool.

- it fixes an issue when trying to select a new option when the url already had dates in. (was trying to find pagination when there was no pagination)
- the second is a feature to run the `handleFilterChange` function when adding the input listener, so if a custom date is added, it will unhide the dates from the start.

### How to review

Sense check it
Pull this branch, run `dp-frontend-search-controller` using `make debug ENABLE_REWORKED_DATA_AGGREGATION_PAGES=true`, port forward the api router to sandbox `dp ssh sandbox web 1 -p 23200:localhost:10800`, head other to [http://localhost:25000/timeseriestool](http://localhost:25000/timeseriestool), play with the 'last updated' dropdown

### Who can review

frontend
