### PR TITLE
remove conditional on select

### DIFF
--- a/src/js/dp/data-aggregation.js
+++ b/src/js/dp/data-aggregation.js
@@ -439,19 +439,17 @@ if (searchContainer) {
 
             break;
         }
-        if (fromYear) {
-          const paramsArray = [
-            {
-              afterYear: fromYear,
-              afterMonth: fromMonth,
-              afterDate: fromDay,
-              beforeYear: toYear,
-              beforeMonth: toMonth,
-              beforeDate: toDay,
-            },
-          ];
-          switchDate(paramsArray);
-        }
+        const paramsArray = [
+          {
+            afterYear: fromYear,
+            afterMonth: fromMonth,
+            afterDate: fromDay,
+            beforeYear: toYear,
+            beforeMonth: toMonth,
+            beforeDate: toDay,
+          },
+        ];
+        switchDate(paramsArray);
       }
     }
 


### PR DESCRIPTION
### What

Originally on the time series tool in `dp-frontend-search-controller`, selecting an option from the 'last updated' dropdown and then selecting the default 'Select last updated' would make the url retain the dates from the first selected option. This resets the url on default selection.

### How to review

Sense check it
Pull this branch, run dp-frontend-search-controller using make debug ENABLE_REWORKED_DATA_AGGREGATION_PAGES=true, port forward the api router to sandbox dp ssh sandbox web 1 -p 23200:localhost:10800, head other to http://localhost:25000/timeseriestool, play with the 'last updated' dropdown.

Who can review
frontend
