### PR TITLE
Add replace for rss link

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -1,4 +1,8 @@
 {
   "ignore": [
+    { 
+      "id": "CVE-2024-4067", 
+      "reason": "A vulnerability of 'braces' a dependency of 'micromatch' which can be ignored https://github.com/micromatch/braces/pull/37#issuecomment-2121649614" 
+    }
   ]
 }

--- a/src/js/dp/data-aggregation.js
+++ b/src/js/dp/data-aggregation.js
@@ -78,6 +78,11 @@ if (searchContainer) {
           searchContainer.querySelector('.search__summary__count'),
           fetchedDom.querySelector('.search__summary__count'),
         );
+
+        replaceWithIEPolyfill(
+          searchContainer.querySelector('.search__rss-link'),
+          fetchedDom.querySelector('.search__rss-link'),
+        );
       }
     }
 


### PR DESCRIPTION
### What

This allows the rss feed link on the aggregation pages to update when new params are added

### How to review

Sense check
_or_
Pull this branch, grab [this branch](https://github.com/ONSdigital/dp-frontend-search-controller/pull/318) of the search controller, run dp-frontend-search-controller using make debug ENABLE_REWORKED_DATA_AGGREGATION_PAGES=true, port forward the api router to sandbox dp ssh sandbox web 1 -p 23200:localhost:10800, head other to http://localhost:25000/datalist and see if the rss link changes when filters are added.

### Who can review

Anyone
