### PR TITLE
Add form validation to data aggregation

### DIFF
--- a/src/js/dp/data-aggregation.js
+++ b/src/js/dp/data-aggregation.js
@@ -389,7 +389,6 @@ if (searchContainer) {
     const afterDateErrs = validateDateFieldset('#before-date');
     if (beforeDateErrs.length > 0 || afterDateErrs.length > 0) {
       const validationErrs = [...beforeDateErrs, ...afterDateErrs];
-      console.log(validationErrs)
       setFormValidation(title, validationErrs, searchContainer, true);
       return;
     }

--- a/src/js/dp/data-aggregation.js
+++ b/src/js/dp/data-aggregation.js
@@ -1,6 +1,10 @@
 import { fetchHtml, replaceWithIEPolyfill } from '../utilities';
+import {
+  clearValidation, validateDateFieldset, setFormValidation, validateDateRange,
+} from './validation/validation';
 
 const searchContainer = document.querySelector('.search__container');
+const { title } = document;
 
 if (searchContainer) {
   const scrollToTopOfSearch = () => {
@@ -376,4 +380,25 @@ if (searchContainer) {
     topFilter.addEventListener('input', () => handleFilterChange(topFilter));
     handleFilterChange(topFilter);
   });
+
+  searchContainer.querySelector('#filterForm').onsubmit = (e) => {
+    e.preventDefault();
+    clearValidation('filterForm', 'search__container', title);
+
+    const beforeDateErrs = validateDateFieldset('#after-date');
+    const afterDateErrs = validateDateFieldset('#before-date');
+    if (beforeDateErrs.length > 0 || afterDateErrs.length > 0) {
+      const validationErrs = [...beforeDateErrs, ...afterDateErrs];
+      console.log(validationErrs)
+      setFormValidation(title, validationErrs, searchContainer, true);
+      return;
+    }
+    const dateRangeErrs = validateDateRange('#after-date', '#before-date');
+    if (dateRangeErrs.length > 0) {
+      setFormValidation(title, dateRangeErrs, searchContainer, true);
+      return;
+    }
+
+    e.target.submit();
+  };
 }


### PR DESCRIPTION
### What

Bring client side [validation](https://trello.com/c/T8PlqbQ3) to the aggregation pages.


### How to review

Sense check
or
Pull this branch, grab https://github.com/ONSdigital/dp-frontend-search-controller/pull/321 of the search controller
Run dp-frontend-search-controller using make debug ENABLE_REWORKED_DATA_AGGREGATION_PAGES=true
Port forward the api router to `sandbox dp ssh sandbox web 1 -p 23200:localhost:10800`
Head other to http://localhost:25000/datalist and play around with the dates.
Any invalidate date should be stopped before it gets into the url.

### Who can review

Frontend
