### PR TITLE
Add styles for osr logo

### DIFF
--- a/src/scss/dp/_styles.scss
+++ b/src/scss/dp/_styles.scss
@@ -24,6 +24,7 @@
 @import "./overrides/components/emergency-banner";
 @import "./overrides/components/service-message";
 @import "./overrides/components/icons";
+@import "./overrides/components/logos";
 @import "./overrides/components/bulletin";
 @import "./overrides/components/feedback-form";
 @import "./overrides/components/census-topics";

--- a/src/scss/dp/overrides/components/_logos.scss
+++ b/src/scss/dp/overrides/components/_logos.scss
@@ -1,0 +1,14 @@
+.osr__logo {
+    display: block;
+    height: 90px;
+    width: 90px;
+    min-height: 90px;
+    min-width: 90px;
+
+    @include breakpoint(sm) {
+        height: 58px;
+        width: 58px;
+        min-height: 58px;
+        min-width: 58px;
+    }
+}


### PR DESCRIPTION
### What

This adds css for the new osr logo. Needed them to be bigger when svg is used. 
It matches the `national-statistics__logo` with just increased size.

### How to review

Make sure looks ok.

### Who can review

Not me.
