### PR TITLE
Feature/update cookie banner

### DIFF
--- a/src/js/dp/cookies-banner.js
+++ b/src/js/dp/cookies-banner.js
@@ -37,7 +37,7 @@ function submitCookieForm(e) {
   const cookiesDomain = extractDomainFromUrl(currentUrl);
   const cookiesPreference = true;
   const encodedCookiesPolicy = '%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D';
-  const defaultCookiesPolicy = '%7B%22essential%22%3Atrue%2C';
+  const defaultCookiesPolicy = '%7B%22essential%22%3Atrue%2C%22usage%22%3Afalse%7D';
   const cookiesPath = '/';
   const cookiesAcceptButton = document.querySelector('.js-accept-cookies');
   const cookiesRejectButton = document.querySelector('.js-reject-cookies');

--- a/src/js/dp/cookies-banner.js
+++ b/src/js/dp/cookies-banner.js
@@ -53,14 +53,17 @@ function submitCookieForm(e) {
   }
 
   document.cookie = `cookies_preferences_set=${cookiesPreference};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
-  if (action === 'accept') {
-    cookiesAcceptedText.classList.remove('hidden');
-
-    document.cookie = `cookies_policy=${encodedCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
-  } else if (action === 'reject') {
-    cookiesRejecedText.classList.remove('hidden');
-
-    document.cookie = `cookies_policy=${defaultCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
+  switch (action) {
+    case 'accept':
+      document.cookie = `cookies_policy=${encodedCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
+      cookiesAcceptedText.classList.remove('hidden');
+      break;
+    case 'reject':
+      document.cookie = `cookies_policy=${defaultCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
+      cookiesRejecedText.classList.remove('hidden');
+      break;
+    default:
+      return;
   }
 
   const informDetails = document.querySelector('.js-cookies-banner-inform');

--- a/src/js/dp/cookies-banner.js
+++ b/src/js/dp/cookies-banner.js
@@ -37,16 +37,31 @@ function submitCookieForm(e) {
   const cookiesDomain = extractDomainFromUrl(currentUrl);
   const cookiesPreference = true;
   const encodedCookiesPolicy = '%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D';
+  const defaultCookiesPolicy = '%7B%22essential%22%3Atrue%2C';
   const cookiesPath = '/';
-  const cookiesAcceptBanner = document.querySelector('.js-accept-cookies');
+  const cookiesAcceptButton = document.querySelector('.js-accept-cookies');
+  const cookiesRejectButton = document.querySelector('.js-reject-cookies');
+  const cookiesAcceptedText = document.querySelector('.ons-js-accepted-text');
+  const cookiesRejecedText = document.querySelector('.ons-js-rejected-text');
+  const action = document.activeElement.getAttribute('data-action');
 
-  if (cookiesAcceptBanner) {
-    cookiesAcceptBanner.disabled = true;
-    cookiesAcceptBanner.classList.add('btn--primary-disabled');
+  if (cookiesAcceptButton || cookiesRejectButton) {
+    cookiesAcceptButton.disabled = true;
+    cookiesAcceptButton.classList.add('btn--primary-disabled');
+    cookiesRejectButton.disabled = true;
+    cookiesRejectButton.classList.add('btn--primary-disabled');
   }
 
   document.cookie = `cookies_preferences_set=${cookiesPreference};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
-  document.cookie = `cookies_policy=${encodedCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
+  if (action === 'accept') {
+    cookiesAcceptedText.classList.remove('hidden');
+
+    document.cookie = `cookies_policy=${encodedCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
+  } else if (action === 'reject') {
+    cookiesRejecedText.classList.remove('hidden');
+
+    document.cookie = `cookies_policy=${defaultCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath};`;
+  }
 
   const informDetails = document.querySelector('.js-cookies-banner-inform');
   if (informDetails) {

--- a/src/scss/dp/overrides/components/_cookies-banner.scss
+++ b/src/scss/dp/overrides/components/_cookies-banner.scss
@@ -18,11 +18,9 @@
 
     &__heading {
         font-weight: 800;
-        font-size: 21px;
-        line-height: 24px;
-        margin-top: 16px;
-        margin-bottom: 0;
-        padding: 3px 0 5px 0;
+        font-size: 26px;
+        line-height: 36px;
+        margin-bottom: 0.5rem !important;
     }
 
     &__body {

--- a/src/scss/dp/overrides/components/_cookies-banner.scss
+++ b/src/scss/dp/overrides/components/_cookies-banner.scss
@@ -51,11 +51,6 @@
             padding: 6px 16px 10px 16px;
         }
 
-        a:hover {
-            color: $lily-white;
-            text-decoration: none;
-        }
-
         @include breakpoint(sm) {
             margin-top: 8px;
             margin-right: 0px;

--- a/src/scss/dp/overrides/components/_cookies-banner.scss
+++ b/src/scss/dp/overrides/components/_cookies-banner.scss
@@ -43,7 +43,7 @@
 
     &__button {
         display: inline-block;
-        margin-right: 8px;
+        padding-right: 1rem;
         
         button {
             padding: 6px 16px 10px 16px;


### PR DESCRIPTION
### What

[Text](https://jira.ons.gov.uk/browse/DIS-2943) update to cookie banner

- Removed hover style for cookie banner links
- Add reject buttons with event listener

### How to review

- Fetch local `dp-renderer` from [PR](https://github.com/ONSdigital/dp-renderer/pull/179) branch
- Changes should be as stated on [Ticket](https://jira.ons.gov.uk/browse/DIS-2943)
  - Accepting or rejecting cookies should display the acceptance or rejection banner
  - Only `Manage settings` should be visible if JS is off
- Check cookies are set if rejected or accepted
  - `cookies_preferences_set` is always set when a button is clicked
  - `essential` and `usage` cookies are set if accepted
  - Only `essential` cookie is set if rejected

![Screenshot 2025-04-22 at 15 54 36](https://github.com/user-attachments/assets/22903add-ecd0-4aa5-8a36-631023279f0a)

![image](https://github.com/user-attachments/assets/f5c81be8-164b-49d4-8ca4-89b4c3171d20)


![image](https://github.com/user-attachments/assets/c894556f-c29e-4424-b334-d4ee6158affd)

![image](https://github.com/user-attachments/assets/426d5ac8-402b-4e6e-aab0-667a31678199)

### Who can review

Anyone
